### PR TITLE
task(dsl): Replace colons with dashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,58 @@ Also try different icon fonts, such as [Font Awesome](http://fontawesome.io/icon
 The values used in the examples below are to be considered placeholder values, and
 the resulting output might not be award-winning.
 
+### Syntax and DSL
+
+The configuration syntax is based on the `ini` file format.
+
+~~~ ini
+[section/name]
+str = My string
+# Hint: Quote the value to keep the spaces
+str = "   My string"
+bool = true
+bool = on
+int = 10
+float = 10.0
+
+# Values for the current bar can be referenced using:
+key = ${BAR.foreground}
+
+# Values for a defined bar can be referenced using:
+key = ${bar/top.foreground}
+
+# Other values can be referenced using:
+key = ${section.key}
+~~~
+
+  > ~~~ ini
+  > format-NAME = "<TAGS...>"
+
+  > ~~~
+
+  > label-NAME[-(foreground|background|(under|over)line|font|padding)] =
+  > icon-NAME[-(foreground|background|(under|over)line|font|padding)] =
+  > ramp-NAME-[0-9]+[-(foreground|background|(under|over)line|font|padding)] =
+  > animation-NAME-[0-9]+[-(foreground|background|(under|over)line|font|padding)] =
+  >
+  > bar-NAME-width =
+  > bar-NAME-format = (tokens- %fill% %indicator% %empty%)
+  > bar-NAME-foreground-[0-9]+ =
+  > bar-NAME-indicator[-(foreground|background|(under|over)line|font|padding)] =
+  > bar-NAME-fill[-(foreground|background|(under|over)line|font|padding)] =
+  > bar-NAME-empty[-(foreground|background|(under|over)line|font|padding)] =
+  >
+  > These keys can be used to style the module container
+  >   format-NAME-spacing = N (unit- whitespace)
+  >   format-NAME-padding = N (unit- whitespace)
+  >   format-NAME-margin = N  (unit- whitespace)
+  >   format-NAME-offset = N  (unit- pixels)
+  >   format-NAME-foreground = #hexcolor
+  >   format-NAME-background = #hexcolor
+  >   format-NAME-underline = #hexcolor
+  >   format-NAME-overline = #hexcolor
+  > ~~~
+
 `🟊 = module is still flagged as work in progress`
 
 
@@ -193,16 +245,16 @@ the resulting output might not be award-winning.
   ;   %percentage% (default)
   label = %percentage%
 
-  ramp:0 = 🌕
-  ramp:1 = 🌔
-  ramp:2 = 🌓
-  ramp:3 = 🌒
-  ramp:4 = 🌑
+  ramp-0 = 🌕
+  ramp-1 = 🌔
+  ramp-2 = 🌓
+  ramp-3 = 🌒
+  ramp-4 = 🌑
 
-  bar:width = 10
-  bar:indicator = |
-  bar:fill = ─
-  bar:empty = ─
+  bar-width = 10
+  bar-indicator = |
+  bar-fill = ─
+  bar-empty = ─
   ~~~
 
 
@@ -228,50 +280,50 @@ the resulting output might not be award-winning.
 ##### Extra formatting (example)
   ~~~ ini
   ; Available tags:
-  ;   <label:charging> (default)
-  ;   <bar:capaity>
-  ;   <ramp:capacity>
-  ;   <animation:charging>
-  format:charging = <animation:charging> <label:charging>
+  ;   <label-charging> (default)
+  ;   <bar-capaity>
+  ;   <ramp-capacity>
+  ;   <animation-charging>
+  format-charging = <animation-charging> <label-charging>
 
   ; Available tags:
-  ;   <label:discharging> (default)
-  ;   <bar:capaity>
-  ;   <ramp:capacity>
-  format:discharging = <ramp:capacity> <label:discharging>
+  ;   <label-discharging> (default)
+  ;   <bar-capaity>
+  ;   <ramp-capacity>
+  format-discharging = <ramp-capacity> <label-discharging>
 
   ; Available tags:
-  ;   <label:full> (default)
-  ;   <bar:capaity>
-  ;   <ramp:capacity>
-  ;format:full = <ramp:capacity> <label:full>
+  ;   <label-full> (default)
+  ;   <bar-capaity>
+  ;   <ramp-capacity>
+  ;format-full = <ramp-capacity> <label-full>
 
   ; Available tokens:
   ;   %percentage% (default)
-  label:charging = Charging %percentage%
+  label-charging = Charging %percentage%
 
   ; Available tokens:
   ;   %percentage% (default)
-  label:discharging = Discharging %percentage%
+  label-discharging = Discharging %percentage%
 
   ; Available tokens:
   ;   %percentage% (default)
-  label:full = Fully charged
+  label-full = Fully charged
 
-  ramp:capacity:0 = 
-  ramp:capacity:1 = 
-  ramp:capacity:2 = 
-  ramp:capacity:3 = 
-  ramp:capacity:4 = 
+  ramp-capacity-0 = 
+  ramp-capacity-1 = 
+  ramp-capacity-2 = 
+  ramp-capacity-3 = 
+  ramp-capacity-4 = 
 
-  bar:capacity:width = 10
+  bar-capacity-width = 10
 
-  animation:charging:0 = 
-  animation:charging:1 = 
-  animation:charging:2 = 
-  animation:charging:3 = 
-  animation:charging:4 = 
-  animation:charging:framerate_ms = 750
+  animation-charging-0 = 
+  animation-charging-1 = 
+  animation-charging-2 = 
+  animation-charging-3 = 
+  animation-charging-4 = 
+  animation-charging-framerate_ms = 750
   ~~~
 
 
@@ -283,72 +335,72 @@ the resulting output might not be award-winning.
 
 ##### Extra formatting (example)
   ~~~ ini
-  ; workspace_icon:[0-9]+ = label;icon
-  workspace_icon:0 = code;♚
-  workspace_icon:1 = office;♛
-  workspace_icon:2 = graphics;♜
-  workspace_icon:3 = mail;♝
-  workspace_icon:4 = web;♞
-  workspace_icon:default = ♟
+  ; workspace_icon-[0-9]+ = label;icon
+  workspace_icon-0 = code;♚
+  workspace_icon-1 = office;♛
+  workspace_icon-2 = graphics;♜
+  workspace_icon-3 = mail;♝
+  workspace_icon-4 = web;♞
+  workspace_icon-default = ♟
 
   ; Available tags:
-  ;   <label:state> (default) - gets replaced with <label:(active|urgent|occupied|empty)>
-  ;   <label:mode> - gets replaced with <label:(monocle|tiled|fullscreen|floating|locked|sticky|private)>
-  format = <label:state> <label:mode>
+  ;   <label-state> (default) - gets replaced with <label-(active|urgent|occupied|empty)>
+  ;   <label-mode> - gets replaced with <label-(monocle|tiled|fullscreen|floating|locked|sticky|private)>
+  format = <label-state> <label-mode>
 
-  ; If any values for label:dimmed:N area defined, the workspace/mode colors will get overridden
+  ; If any values for label-dimmed-N area defined, the workspace/mode colors will get overridden
   ; with those values if the monitor is out of focus
-  label:dimmed:foreground = #555
-  label:dimmed:underline = ${BAR.background}
+  label-dimmed-foreground = #555
+  label-dimmed-underline = ${BAR.background}
 
   ; Available tokens:
   ;   %name%
   ;   %icon%
   ;   %index%
   ; Default: %icon%  %name%
-  label:active = %icon%
-  label:active:foreground = #ffffff
-  label:active:background = #3f3f3f
-  label:active:underline = #fba922
+  label-active = %icon%
+  label-active-foreground = #ffffff
+  label-active-background = #3f3f3f
+  label-active-underline = #fba922
 
   ; Available tokens:
   ;   %name%
   ;   %icon%
   ;   %index%
   ; Default: %icon%  %name%
-  label:occupied = %icon%
-  label:occupied:underline = #555555
+  label-occupied = %icon%
+  label-occupied-underline = #555555
 
   ; Available tokens:
   ;   %name%
   ;   %icon%
   ;   %index%
   ; Default: %icon%  %name%
-  label:urgent = %icon%
-  label:urgent:foreground = #000000
-  label:urgent:background = #bd2c40
-  label:urgent:underline = #9b0a20
+  label-urgent = %icon%
+  label-urgent-foreground = #000000
+  label-urgent-background = #bd2c40
+  label-urgent-underline = #9b0a20
 
   ; Available tokens:
   ;   %name%
   ;   %icon%
   ;   %index%
   ; Default: %icon%  %name%
-  label:empty = %icon%
-  label:empty:foreground = #55ffffff
+  label-empty = %icon%
+  label-empty-foreground = #55ffffff
 
   ; Available tokens:
   ;   None
-  label:monocle = 
-  ;label:tiled = 
-  ;label:fullscreen = 
-  ;label:floating = 
-  label:locked = 
-  label:locked:foreground = #bd2c40
-  label:sticky = 
-  label:sticky:foreground = #fba922
-  label:private = 
-  label:private:foreground = #bd2c40
+  label-monocle = 
+  ;label-tiled = 
+  ;label-fullscreen = 
+  ;label-floating = 
+  label-locked = 
+  label-locked-foreground = #bd2c40
+  label-sticky = 
+  label-sticky-foreground = #fba922
+  label-private = 
+  label-private-foreground = #bd2c40
   ~~~
 
 
@@ -365,23 +417,23 @@ the resulting output might not be award-winning.
   ~~~ ini
   ; Available tags:
   ;   <label> (default)
-  ;   <bar:load>
-  ;   <ramp:load>
-  ;   <ramp:load_per_core>
-  format = <label> <ramp:load_per_core>
+  ;   <bar-load>
+  ;   <ramp-load>
+  ;   <ramp-load_per_core>
+  format = <label> <ramp-load_per_core>
 
   ; Available tokens:
   ;   %percentage% (default) - total cpu load
   label = CPU %percentage%
 
-  ramp:load_per_core:0 = ▁
-  ramp:load_per_core:1 = ▂
-  ramp:load_per_core:2 = ▃
-  ramp:load_per_core:3 = ▄
-  ramp:load_per_core:4 = ▅
-  ramp:load_per_core:5 = ▆
-  ramp:load_per_core:6 = ▇
-  ramp:load_per_core:7 = █
+  ramp-load_per_core-0 = ▁
+  ramp-load_per_core-1 = ▂
+  ramp-load_per_core-2 = ▃
+  ramp-load_per_core-3 = ▄
+  ramp-load_per_core-4 = ▅
+  ramp-load_per_core-5 = ▆
+  ramp-load_per_core-6 = ▇
+  ramp-load_per_core-7 = █
   ~~~
 
 
@@ -398,7 +450,7 @@ the resulting output might not be award-winning.
   date = %Y-%m-%d% %H:%M
 
   ; if date_detailed is defined, clicking the area will toggle between formats
-  date_detailed = %%{F#888}%A, %d %B %Y%  %%{F#fff}%H:%M%%{F#666}:%%{F#fba922}%S%%{F-}
+  date_detailed = %%{F#888}%A, %d %B %Y  %%{F#fff}%H:%M%%{F#666}:%%{F#fba922}%S%%{F-}
   ~~~
 
 ##### Extra formatting (example)
@@ -406,8 +458,8 @@ the resulting output might not be award-winning.
   ; Available tags:
   ;   <date> (default)
   format = 🕓 <date>
-  format:background = #55ff3399
-  format:foreground = #fff
+  format-background = #55ff3399
+  format-foreground = #fff
   ~~~
 
 
@@ -419,7 +471,7 @@ see [the dependency section](#user-content-dependencies).
 The module is still marked as WIP since it needs more testing. If you notice any
 anomalies, please [create an issue](https://github.com/jaagr/lemonbuddy/issues).
 
-See [the bspwm module](#user-content-dependencies) for details on `label:dimmed`.
+See [the bspwm module](#user-content-dependencies) for details on `label-dimmed`.
 
   ~~~ ini
   [module/i3]
@@ -428,55 +480,55 @@ See [the bspwm module](#user-content-dependencies) for details on `label:dimmed`
 
 ##### Extra formatting (example)
   ~~~ ini
-  ; workspace_icon:[0-9]+ = label;icon
-  workspace_icon:0 = 1;♚
-  workspace_icon:1 = 2;♛
-  workspace_icon:2 = 3;♜
-  workspace_icon:3 = 4;♝
-  workspace_icon:4 = 5;♞
-  workspace_icon:default = ♟
+  ; workspace_icon-[0-9]+ = label;icon
+  workspace_icon-0 = 1;♚
+  workspace_icon-1 = 2;♛
+  workspace_icon-2 = 3;♜
+  workspace_icon-3 = 4;♝
+  workspace_icon-4 = 5;♞
+  workspace_icon-default = ♟
 
   ; Available tags:
-  ;   <label:state> (default) - gets replaced with <label:(focused|unfocused|visible|urgent)>
-  ;format = <label:state>
+  ;   <label-state> (default) - gets replaced with <label-(focused|unfocused|visible|urgent)>
+  ;format = <label-state>
 
   ; Available tokens:
   ;   %name%
   ;   %icon%
   ;   %index%
   ; Default: %icon%  %name%
-  label:focused = %icon%
-  label:focused:foreground = #ffffff
-  label:focused:background = #3f3f3f
-  label:focused:underline = #fba922
-  label:focused:padding = 4
+  label-focused = %icon%
+  label-focused-foreground = #ffffff
+  label-focused-background = #3f3f3f
+  label-focused-underline = #fba922
+  label-focused-padding = 4
 
   ; Available tokens:
   ;   %name%
   ;   %icon%
   ;   %index%
   ; Default: %icon%  %name%
-  label:unfocused = %icon%
-  label:unfocused:padding = 4
+  label-unfocused = %icon%
+  label-unfocused-padding = 4
 
   ; Available tokens:
   ;   %name%
   ;   %icon%
   ;   %index%
   ; Default: %icon%  %name%
-  label:visible = %icon%
-  label:visible:underline = #555555
-  label:visible:padding = 4
+  label-visible = %icon%
+  label-visible-underline = #555555
+  label-visible-padding = 4
 
   ; Available tokens:
   ;   %name%
   ;   %icon%
   ;   %index%
   ; Default: %icon%  %name%
-  label:urgent = %icon%
-  label:urgent:foreground = #000000
-  label:urgent:background = #bd2c40
-  label:urgent:padding = 4
+  label-urgent = %icon%
+  label-urgent-foreground = #000000
+  label-urgent-background = #bd2c40
+  label-urgent-padding = 4
   ~~~
 
 
@@ -493,9 +545,9 @@ See [the bspwm module](#user-content-dependencies) for details on `label:dimmed`
   ~~~ ini
   ; Available tags:
   ;   <label> (default)
-  ;   <bar:used>
-  ;   <bar:free>
-  format = <label> <bar:used>
+  ;   <bar-used>
+  ;   <bar-free>
+  format = <label> <bar-used>
 
   ; Available tokens:
   ;   %percentage_used% (default)
@@ -508,14 +560,14 @@ See [the bspwm module](#user-content-dependencies) for details on `label:dimmed`
   ;   %mb_total%
   label = RAM %percentage_used%
 
-  bar:used:width = 50
-  bar:used:foreground:0 = #55aa55
-  bar:used:foreground:1 = #557755
-  bar:used:foreground:2 = #f5a70a
-  bar:used:foreground:3 = #ff5555
-  bar:used:fill = ▐
-  bar:used:empty = ▐
-  bar:used:empty:foreground = #444444
+  bar-used-width = 50
+  bar-used-foreground-0 = #55aa55
+  bar-used-foreground-1 = #557755
+  bar-used-foreground-2 = #f5a70a
+  bar-used-foreground-3 = #ff5555
+  bar-used-fill = ▐
+  bar-used-empty = ▐
+  bar-used-empty-foreground = #444444
   ~~~
 
 
@@ -531,58 +583,58 @@ See [the bspwm module](#user-content-dependencies) for details on `label:dimmed`
 ##### Extra formatting (example)
   ~~~ ini
   ; Available tags:
-  ;   <label:song> (default)
-  ;   <label:time>
-  ;   <bar:progress>
-  ;   <toggle> - gets replaced with <icon:(pause|play)>
-  ;   <icon:random>
-  ;   <icon:repeat>
-  ;   <icon:repeatone>
-  ;   <icon:prev>
-  ;   <icon:stop>
-  ;   <icon:play>
-  ;   <icon:pause>
-  ;   <icon:next>
-  format:online = <icon:prev> <icon:stop> <toggle> <icon:next>  <icon:repeat> <icon:random>  <bar:progress> <label:time>  <label:song>
+  ;   <label-song> (default)
+  ;   <label-time>
+  ;   <bar-progress>
+  ;   <toggle> - gets replaced with <icon-(pause|play)>
+  ;   <icon-random>
+  ;   <icon-repeat>
+  ;   <icon-repeatone>
+  ;   <icon-prev>
+  ;   <icon-stop>
+  ;   <icon-play>
+  ;   <icon-pause>
+  ;   <icon-next>
+  format-online = <icon-prev> <icon-stop> <toggle> <icon-next>  <icon-repeat> <icon-random>  <bar-progress> <label-time>  <label-song>
 
   ; Available tags:
-  ;   <label:offline>
-  ;format:offline = <label:offline>
+  ;   <label-offline>
+  ;format-offline = <label-offline>
 
   ; Available tokens:
   ;   %artist%
   ;   %album%
   ;   %title%
   ; Default: %artist% - %title%
-  ;label:song = 𝄞 %artist% - %title%
+  ;label-song = 𝄞 %artist% - %title%
 
   ; Available tokens:
   ;   %elapsed%
   ;   %total%
   ; Default: %elapsed% / %total%
-  ;label:time = %elapsed% / %total%
+  ;label-time = %elapsed% / %total%
 
   ; Available tokens:
   ;   None
-  label:offline = 🎜 mpd is offline
+  label-offline = 🎜 mpd is offline
 
-  icon:play = ⏵
-  icon:pause = ⏸
-  icon:stop = ⏹
-  icon:prev = ⏮
-  icon:next = ⏭
-  icon:random = 🔀
-  icon:repeat = 🔁
-  ;icon:repeatone = 🔂
+  icon-play = ⏵
+  icon-pause = ⏸
+  icon-stop = ⏹
+  icon-prev = ⏮
+  icon-next = ⏭
+  icon-random = 🔀
+  icon-repeat = 🔁
+  ;icon-repeatone = 🔂
 
   ; Used to display the state of random/repeat/repeatone
-  toggle_on:foreground = #ff
-  toggle_off:foreground = #55
+  toggle_on-foreground = #ff
+  toggle_off-foreground = #55
 
-  bar:progress:width = 45
-  bar:progress:indicator = |
-  bar:progress:fill = ─
-  bar:progress:empty = ─
+  bar-progress-width = 45
+  bar-progress-indicator = |
+  bar-progress-fill = ─
+  bar-progress-empty = ─
   ~~~
 
 
@@ -620,19 +672,19 @@ See [the bspwm module](#user-content-dependencies) for details on `label:dimmed`
 ##### Extra formatting (example)
   ~~~ ini
   ; Available tags:
-  ;   <label:connected> (default)
-  ;   <ramp:signal>
-  format:connected = <ramp:signal> <label:connected>
+  ;   <label-connected> (default)
+  ;   <ramp-signal>
+  format-connected = <ramp-signal> <label-connected>
 
   ; Available tags:
-  ;   <label:disconnected> (default)
-  ;format:disconnected = <label:disconnected>
+  ;   <label-disconnected> (default)
+  ;format-disconnected = <label-disconnected>
 
   ; Available tags:
-  ;   <label:connected> (default)
-  ;   <label:packetloss>
-  ;   <animation:packetloss>
-  format:packetloss = <animation:packetloss> <label:connected>
+  ;   <label-connected> (default)
+  ;   <label-packetloss>
+  ;   <animation-packetloss>
+  format-packetloss = <animation-packetloss> <label-connected>
 
   ; Available tokens:
   ;   %ifname%    [wireless+wired]
@@ -641,14 +693,14 @@ See [the bspwm module](#user-content-dependencies) for details on `label:dimmed`
   ;   %signal%    [wireless]
   ;   %linkspeed% [wired]
   ; Default: %ifname% %local_ip%
-  label:connected = %essid%
-  label:connected:foreground = #eefafafa
+  label-connected = %essid%
+  label-connected-foreground = #eefafafa
 
   ; Available tokens:
   ;   %ifname%    [wireless+wired]
   ; Default: (none)
-  ;label:disconnected = not connected
-  ;label:disconnected:foreground = #66ffffff
+  ;label-disconnected = not connected
+  ;label-disconnected-foreground = #66ffffff
 
   ; Available tokens:
   ;   %ifname%    [wireless+wired]
@@ -657,21 +709,21 @@ See [the bspwm module](#user-content-dependencies) for details on `label:dimmed`
   ;   %signal%    [wireless]
   ;   %linkspeed% [wired]
   ; Default: (none)
-  ;label:packetloss = %essid%
-  ;label:packetloss:foreground = #eefafafa
+  ;label-packetloss = %essid%
+  ;label-packetloss-foreground = #eefafafa
 
-  ramp:signal:0 = 😱
-  ramp:signal:1 = 😠
-  ramp:signal:2 = 😒
-  ramp:signal:3 = 😊
-  ramp:signal:4 = 😃
-  ramp:signal:5 = 😈
+  ramp-signal-0 = 😱
+  ramp-signal-1 = 😠
+  ramp-signal-2 = 😒
+  ramp-signal-3 = 😊
+  ramp-signal-4 = 😃
+  ramp-signal-5 = 😈
 
-  animation:packetloss:0 = ⚠
-  animation:packetloss:0:foreground = #ffa64c
-  animation:packetloss:1 = 📶
-  animation:packetloss:1:foreground = #000000
-  animation:packetloss:framerate_ms = 500
+  animation-packetloss-0 = ⚠
+  animation-packetloss-0-foreground = #ffa64c
+  animation-packetloss-1 = 📶
+  animation-packetloss-1-foreground = #000000
+  animation-packetloss-framerate_ms = 500
   ~~~
 
 
@@ -700,30 +752,29 @@ See [the bspwm module](#user-content-dependencies) for details on `label:dimmed`
 ##### Extra formatting (example)
   ~~~ ini
   ; Available tags:
-  ;   <label:volume> (default)
-  ;   <ramp:volume>
-  ;   <bar:volume>
-  format:volume = <ramp:volume> <label:volume>
+  ;   <label-volume> (default)
+  ;   <ramp-volume>
+  ;   <bar-volume>
+  format-volume = <ramp-volume> <label-volume>
 
   ; Available tags:
-  ;   <label:muted> (default)
-  ;   <ramp:volume>
-  ;   <bar:volume>
-  ;format:muted = <label:muted>
+  ;   <label-muted> (default)
+  ;   <ramp-volume>
+  ;   <bar-volume>
+  ;format-muted = <label-muted>
 
   ; Available tokens:
   ;   %percentage% (default)
-  ;label:volume = %percentage%
+  ;label-volume = %percentage%
 
   ; Available tokens:
   ;   %percentage% (default)
-  label:muted = 🔇 muted
-  label:muted:foreground = #66
+  label-muted = 🔇 muted
+  label-muted-foreground = #66
 
-  ; Required if <ramp:volume> is used
-  ramp:volume:0 = 🔈
-  ramp:volume:1 = 🔉
-  ramp:volume:2 = 🔊
+  ramp-volume-0 = 🔈
+  ramp-volume-1 = 🔉
+  ramp-volume-2 = 🔊
   ~~~
 
 
@@ -732,45 +783,45 @@ See [the bspwm module](#user-content-dependencies) for details on `label:dimmed`
   [module/menu-apps]
   type = custom/menu
 
-  ; "menu:LEVEL:N" has the same properties as "label:NAME" with
+  ; "menu-LEVEL-N" has the same properties as "label-NAME" with
   ; the additional "exec" property
   ;
   ; Available exec commands:
-  ;   menu_open:LEVEL
+  ;   menu_open-LEVEL
   ;   menu_close
   ; Other commands will be executed using "/usr/bin/env sh -c $COMMAND"
 
-  menu:0:0 = Browsers
-  menu:0:0:exec = menu_open:1
-  menu:0:0:foreground = #fba922
-  menu:0:2 = Multimedia
-  menu:0:2:exec = menu_open:3
-  menu:0:2:foreground = #fba922
+  menu-0-0 = Browsers
+  menu-0-0-exec = menu_open-1
+  menu-0-0-foreground = #fba922
+  menu-0-2 = Multimedia
+  menu-0-2-exec = menu_open-3
+  menu-0-2-foreground = #fba922
 
-  menu:1:0 = Firefox
-  menu:1:0:exec = firefox &
-  menu:1:0:foreground = #fba922
-  menu:1:1 = Chromium
-  menu:1:1:exec = chromium &
-  menu:1:1:foreground = #fba922
+  menu-1-0 = Firefox
+  menu-1-0-exec = firefox &
+  menu-1-0-foreground = #fba922
+  menu-1-1 = Chromium
+  menu-1-1-exec = chromium &
+  menu-1-1-foreground = #fba922
 
-  menu:2:0 = Gimp
-  menu:2:0:foreground = #fba922
-  menu:2:0:exec = gimp &
-  menu:2:1 = Scrot
-  menu:2:1:exec = scrot &
-  menu:2:1:foreground = #fba922
+  menu-2-0 = Gimp
+  menu-2-0-foreground = #fba922
+  menu-2-0-exec = gimp &
+  menu-2-1 = Scrot
+  menu-2-1-exec = scrot &
+  menu-2-1-foreground = #fba922
   ~~~
 
 ##### Extra formatting (example)
   ~~~ ini
   ; Available tags:
-  ;   <label:toggle> (default) - gets replaced with <label:(open|close)>
+  ;   <label-toggle> (default) - gets replaced with <label-(open|close)>
   ;   <menu> (default)
-  ;format = <label:toggle> <menu>
+  ;f-ormat = <label-toggle> <menu>
 
-  label:open = Apps
-  label:close = x
+  label-open = Apps
+  label-close = x
   ~~~
 
 
@@ -794,24 +845,24 @@ See [the bspwm module](#user-content-dependencies) for details on `label:dimmed`
   ; Available tags:
   ;   <output> (default)
   ;format = <output>
-  format:background = #999
-  format:foreground = #000
-  format:padding = 4
+  format-background = #999
+  format-foreground = #000
+  format-padding = 4
 
   ; Available tokens:
   ;   %counter%
   ;
-  ; "click:(left|middle|right)" will be executed using "/usr/bin/env sh -c [command]"
-  click:left = echo left %counter%
-  click:middle = echo middle %counter%
-  click:right = echo right %counter%
+  ; "click-(left|middle|right)" will be executed using "/usr/bin/env sh -c [command]"
+  click-left = echo left %counter%
+  click-middle = echo middle %counter%
+  click-right = echo right %counter%
 
   ; Available tokens:
   ;   %counter%
   ;
-  ; "scroll:(up|down)" will be executed using "/usr/bin/env sh -c [command]"
-  scroll:up = echo scroll up %counter%
-  scroll:down = echo scroll down %counter%
+  ; "scroll-(up|down)" will be executed using "/usr/bin/env sh -c [command]"
+  scroll-up = echo scroll up %counter%
+  scroll-down = echo scroll down %counter%
   ~~~
 
 ##### Useful example
@@ -834,19 +885,19 @@ See [the bspwm module](#user-content-dependencies) for details on `label:dimmed`
 
 ##### Extra formatting (example)
   ~~~ ini
-  ; "content" has the same properties as "format:NAME"
-  content:background = #000
-  content:foreground = #fff
-  content:padding = 4
+  ; "content" has the same properties as "format-NAME"
+  content-background = #000
+  content-foreground = #fff
+  content-padding = 4
 
-  ; "click:(left|middle|right)" will be executed using "/usr/bin/env sh -c $COMMAND"
-  click:left = echo left
-  click:middle = echo middle
-  click:right = echo right
+  ; "click-(left|middle|right)" will be executed using "/usr/bin/env sh -c $COMMAND"
+  click-left = echo left
+  click-middle = echo middle
+  click-right = echo right
 
-  ; "scroll:(up|down)" will be executed using "/usr/bin/env sh -c $COMMAND"
-  scroll:up = echo scroll up
-  scroll:down = echo scroll down
+  ; "scroll-(up|down)" will be executed using "/usr/bin/env sh -c $COMMAND"
+  scroll-up = echo scroll up
+  scroll-down = echo scroll down
   ~~~
 
 

--- a/config
+++ b/config
@@ -18,28 +18,28 @@ throttle_ms = 50
 ; Other values can be referenced using:
 ;   ${section.key}
 ;
-; format:NAME = <TAG...>
-; label:NAME[:(foreground|background|(under|over)line|font|padding)] =
-; icon:NAME[:(foreground|background|(under|over)line|font|padding)] =
-; ramp:NAME:[0-9]+[:(foreground|background|(under|over)line|font|padding)] =
-; animation:NAME:[0-9]+[:(foreground|background|(under|over)line|font|padding)] =
+; format-NAME = <TAG...>
+; label-NAME[-(foreground|background|(under|over)line|font|padding)] =
+; icon-NAME[-(foreground|background|(under|over)line|font|padding)] =
+; ramp-NAME-[0-9]+[-(foreground|background|(under|over)line|font|padding)] =
+; animation-NAME-[0-9]+[-(foreground|background|(under|over)line|font|padding)] =
 ;
-; bar:NAME:width =
-; bar:NAME:format = (tokens: %fill% %indicator% %empty%)
-; bar:NAME:foreground:[0-9]+ =
-; bar:NAME:indicator[:(foreground|background|(under|over)line|font|padding)] =
-; bar:NAME:fill[:(foreground|background|(under|over)line|font|padding)] =
-; bar:NAME:empty[:(foreground|background|(under|over)line|font|padding)] =
+; bar-NAME-width =
+; bar-NAME-format = (tokens: %fill% %indicator% %empty%)
+; bar-NAME-foreground-[0-9]+ =
+; bar-NAME-indicator[-(foreground|background|(under|over)line|font|padding)] =
+; bar-NAME-fill[-(foreground|background|(under|over)line|font|padding)] =
+; bar-NAME-empty[-(foreground|background|(under|over)line|font|padding)] =
 ;
 ; These keys can be used to style the module container
-;   format:NAME:spacing = N (unit: whitespace)
-;   format:NAME:padding = N (unit: whitespace)
-;   format:NAME:margin = N  (unit: whitespace)
-;   format:NAME:offset = N  (unit: pixels)
-;   format:NAME:foreground = #hexcolor
-;   format:NAME:background = #hexcolor
-;   format:NAME:underline = #hexcolor
-;   format:NAME:overline = #hexcolor
+;   format-NAME-spacing = N (unit: whitespace)
+;   format-NAME-padding = N (unit: whitespace)
+;   format-NAME-margin = N  (unit: whitespace)
+;   format-NAME-offset = N  (unit: pixels)
+;   format-NAME-foreground = #hexcolor
+;   format-NAME-background = #hexcolor
+;   format-NAME-underline = #hexcolor
+;   format-NAME-overline = #hexcolor
 ;
 ; Module types:
 ;   internal/backlight
@@ -55,20 +55,20 @@ throttle_ms = 50
 ;
 ;   custom/text
 ;     content
-;     click:(left|middle|right)
-;     scroll:(up|down)
+;     click-(left|middle|right)
+;     scroll-(up|down)
 ;   custom/script
 ;     exec
 ;     interval
 ;     format
-;     click:(left|middle|right)
-;     scroll:(up|down)
+;     click-(left|middle|right)
+;     scroll-(up|down)
 ;   custom/menu
 ;     format
-;     label:open
-;     label:close
-;     menu:LEVEL:n
-;     menu:LEVEL:n:exec
+;     label-open
+;     label-close
+;     menu-LEVEL-n
+;     menu-LEVEL-n-exec
 ;
 
 [bar/top]
@@ -90,14 +90,14 @@ lineheight = 14
 module_margin_left = 3
 module_margin_right = 3
 
-font:0 = NotoSans-Regular:size=8;0
-font:1 = MaterialIcons:size=10;0
-font:2 = Termsynu:size=8;-1
-font:3 = FontAwesome:size=10;0
+font-0 = NotoSans-Regular:size=8;0
+font-1 = MaterialIcons:size=10;0
+font-2 = Termsynu:size=8;-1
+font-3 = FontAwesome:size=10;0
 
-; modules:left = powermenu mpd
-; modules:right = backlight volume wireless-network wired-network battery date
-modules:right = battery
+modules-left = powermenu mpd
+modules-right = backlight volume wireless-network wired-network battery date
+; modules-right = battery
 
 [bar/bottom]
 monitor = eDP-1
@@ -117,17 +117,17 @@ padding_right = 4
 module_margin_left = 0
 module_margin_right = 6
 
-; font:idx = font:size=N;offsetY
-font:0 = NotoSans-Regular:size=8;0
-font:1 = Unifont:size=6;-3
-;font:1 = Termsynu:size=8;-1
-font:2 = FontAwesome:size=8;-2
-font:3 = NotoSans-Regular:size=8;-1
-font:4 = MaterialIcons:size=10;-1
+; font-idx = font:size=N;offsetY
+font-0 = NotoSans-Regular:size=8;0
+font-1 = Unifont:size=6;-3
+;font-1 = Termsynu:size=8;-1
+font-2 = FontAwesome:size=8;-2
+font-3 = NotoSans-Regular:size=8;-1
+font-4 = MaterialIcons:size=10;-1
 
-modules:left = bspwm
-modules:right = rtorrent cpu memory
-; modules:right = cpu memory
+modules-left = bspwm
+modules-right = rtorrent cpu memory
+; modules-right = cpu memory
 
 [bar/external_bottom]
 monitor = HDMI-1
@@ -147,14 +147,14 @@ padding_right = 3
 module_margin_left = 0
 module_margin_right = 6
 
-font:0 = NotoSans-Regular:size=8;0
-font:1 = Unifont:size=6;-3
-font:2 = FontAwesome:size=8;-2
-font:3 = NotoSans-Regular:size=8;-1
-font:4 = MaterialIcons:size=10;0
+font-0 = NotoSans-Regular:size=8;0
+font-1 = Unifont:size=6;-3
+font-2 = FontAwesome:size=8;-2
+font-3 = NotoSans-Regular:size=8;-1
+font-4 = MaterialIcons:size=10;0
 
-modules:left = bspwm
-modules:right = clock
+modules-left = bspwm
+modules-right = clock
 
 
 [module/backlight]
@@ -174,22 +174,22 @@ format = %{A4:backlight_percentage%__p5:}%{A5:backlight_percentage%__m5:} <ramp>
 ;label = %percentage%
 
 ; Required if <ramp> is used
-ramp:0 = 
-ramp:1 = 
-ramp:2 = 
+ramp-0 = 
+ramp-1 = 
+ramp-2 = 
 
 ; Required if <bar> is used
-bar:width = 10
-bar:format = %{+u}%{+o}%fill%%{-u}%{-o}%indicator%%{+u}%{+o}%empty%%{-u}%{-o}
-bar:indicator = |
-bar:indicator:foreground = #ddffffff
-bar:indicator:font = 3
-bar:fill = █
-bar:fill:foreground = #99ffffff
-bar:fill:font = 3
-bar:empty = █
-bar:empty:font = 3
-bar:empty:foreground = #44ffffff
+bar-width = 10
+bar-format = %{+u}%{+o}%fill%%{-u}%{-o}%indicator%%{+u}%{+o}%empty%%{-u}%{-o}
+bar-indicator = |
+bar-indicator-foreground = #ddffffff
+bar-indicator-font = 3
+bar-fill = █
+bar-fill-foreground = #99ffffff
+bar-fill-font = 3
+bar-empty = █
+bar-empty-font = 3
+bar-empty-foreground = #44ffffff
 
 [module/battery]
 type = internal/battery
@@ -199,247 +199,247 @@ type = internal/battery
 full_at = 99
 
 ; Available tags:
-;   <label:charging> (default)
-;   <bar:capaity>
-;   <ramp:capacity>
-;   <animation:charging>
-format:charging = Charging <animation:charging> <label:charging>
+;   <label-charging> (default)
+;   <bar-capaity>
+;   <ramp-capacity>
+;   <animation-charging>
+format-charging = Charging <animation-charging> <label-charging>
 
 ; Available tags:
-;   <label:discharging> (default)
-;   <bar:capaity>
-;   <ramp:capacity>
-format:discharging = Discharging <ramp:capacity> <label:discharging>
+;   <label-discharging> (default)
+;   <bar-capaity>
+;   <ramp-capacity>
+format-discharging = Discharging <ramp-capacity> <label-discharging>
 
 ; Available tags:
-;   <label:full> (default)
-;   <bar:capaity>
-;   <ramp:capacity>
-format:full = Fully charged <ramp:capacity> <label:full>
+;   <label-full> (default)
+;   <bar-capaity>
+;   <ramp-capacity>
+format-full = Fully charged <ramp-capacity> <label-full>
 
 ; Available tokens:
 ;   %percentage% (default)
-;label:charging = Charging %percentage%
+;label-charging = Charging %percentage%
 
 ; Available tokens:
 ;   %percentage% (default)
-;label:discharging = Discharging %percentage%
+;label-discharging = Discharging %percentage%
 
 ; Available tokens:
 ;   %percentage% (default)
-;label:full = Fully charged
+;label-full = Fully charged
 
-; Required if <ramp:capacity> is used
-ramp:capacity:0 = 
-ramp:capacity:0:foreground = #f53c3c
-ramp:capacity:1 = 
-ramp:capacity:1:foreground = #ffa900
-ramp:capacity:2 = 
-ramp:capacity:2:foreground = #ffffff
-ramp:capacity:3 = 
-ramp:capacity:3:foreground = #ffffff
-ramp:capacity:4 = 
-ramp:capacity:4:foreground = #ffffff
+; Required if <ramp-capacity> is used
+ramp-capacity-0 = 
+ramp-capacity-0-foreground = #f53c3c
+ramp-capacity-1 = 
+ramp-capacity-1-foreground = #ffa900
+ramp-capacity-2 = 
+ramp-capacity-2-foreground = #ffffff
+ramp-capacity-3 = 
+ramp-capacity-3-foreground = #ffffff
+ramp-capacity-4 = 
+ramp-capacity-4-foreground = #ffffff
 
-; Required if <bar:capacity> is used
-bar:capacity:width = 10
-bar:capacity:format = %{+u}%{+o}%fill%%empty%%{-u}%{-o}
-bar:capacity:fill = █
-bar:capacity:fill:foreground = #ddffffff
-bar:capacity:fill:font = 3
-bar:capacity:empty = █
-bar:capacity:empty:font = 3
-bar:capacity:empty:foreground = #44ffffff
+; Required if <bar-capacity> is used
+bar-capacity-width = 10
+bar-capacity-format = %{+u}%{+o}%fill%%empty%%{-u}%{-o}
+bar-capacity-fill = █
+bar-capacity-fill-foreground = #ddffffff
+bar-capacity-fill-font = 3
+bar-capacity-empty = █
+bar-capacity-empty-font = 3
+bar-capacity-empty-foreground = #44ffffff
 
-; Required if <animation:charging> is used
-; animation:charging:0 = %{T3}%{F#ddffffff}%{+u}%{+o}█%{F#44ffffff}█████████%{T-}%{F-}%{-u}%{-o}
-; animation:charging:1 = %{T3}%{F#ddffffff}%{+u}%{+o}██%{F#44ffffff}████████%{T-}%{F-}%{-u}%{-o}
-; animation:charging:2 = %{T3}%{F#ddffffff}%{+u}%{+o}███%{F#44ffffff}███████%{T-}%{F-}%{-u}%{-o}
-; animation:charging:3 = %{T3}%{F#ddffffff}%{+u}%{+o}████%{F#44ffffff}██████%{T-}%{F-}%{-u}%{-o}
-; animation:charging:4 = %{T3}%{F#ddffffff}%{+u}%{+o}█████%{F#44ffffff}█████%{T-}%{F-}%{-u}%{-o}
-; animation:charging:5 = %{T3}%{F#ddffffff}%{+u}%{+o}██████%{F#44ffffff}████%{T-}%{F-}%{-u}%{-o}
-; animation:charging:6 = %{T3}%{F#ddffffff}%{+u}%{+o}███████%{F#44ffffff}███%{T-}%{F-}%{-u}%{-o}
-; animation:charging:7 = %{T3}%{F#ddffffff}%{+u}%{+o}████████%{F#44ffffff}██%{T-}%{F-}%{-u}%{-o}
-; animation:charging:8 = %{T3}%{F#ddffffff}%{+u}%{+o}█████████%{F#44ffffff}█%{T-}%{F-}%{-u}%{-o}
-; animation:charging:9 = %{T3}%{F#ddffffff}%{+u}%{+o}██████████%{T-}%{F-}%{-u}%{-o}
-animation:charging:0 = 
-animation:charging:1 = 
-animation:charging:2 = 
-animation:charging:3 = 
-animation:charging:4 = 
-animation:charging:framerate_ms = 750
+; Required if <animation-charging> is used
+; animation-charging-0 = %{T3}%{F#ddffffff}%{+u}%{+o}█%{F#44ffffff}█████████%{T-}%{F-}%{-u}%{-o}
+; animation-charging-1 = %{T3}%{F#ddffffff}%{+u}%{+o}██%{F#44ffffff}████████%{T-}%{F-}%{-u}%{-o}
+; animation-charging-2 = %{T3}%{F#ddffffff}%{+u}%{+o}███%{F#44ffffff}███████%{T-}%{F-}%{-u}%{-o}
+; animation-charging-3 = %{T3}%{F#ddffffff}%{+u}%{+o}████%{F#44ffffff}██████%{T-}%{F-}%{-u}%{-o}
+; animation-charging-4 = %{T3}%{F#ddffffff}%{+u}%{+o}█████%{F#44ffffff}█████%{T-}%{F-}%{-u}%{-o}
+; animation-charging-5 = %{T3}%{F#ddffffff}%{+u}%{+o}██████%{F#44ffffff}████%{T-}%{F-}%{-u}%{-o}
+; animation-charging-6 = %{T3}%{F#ddffffff}%{+u}%{+o}███████%{F#44ffffff}███%{T-}%{F-}%{-u}%{-o}
+; animation-charging-7 = %{T3}%{F#ddffffff}%{+u}%{+o}████████%{F#44ffffff}██%{T-}%{F-}%{-u}%{-o}
+; animation-charging-8 = %{T3}%{F#ddffffff}%{+u}%{+o}█████████%{F#44ffffff}█%{T-}%{F-}%{-u}%{-o}
+; animation-charging-9 = %{T3}%{F#ddffffff}%{+u}%{+o}██████████%{T-}%{F-}%{-u}%{-o}
+animation-charging-0 = 
+animation-charging-1 = 
+animation-charging-2 = 
+animation-charging-3 = 
+animation-charging-4 = 
+animation-charging-framerate_ms = 750
 
 [module/bspwm]
 type = internal/bspwm
 
-; workspace_icon:[0-9]+ = label;icon
-; workspace_icon:default = icon
-workspace_icon:0 = term;
-workspace_icon:1 = web;
-workspace_icon:2 = code;
-workspace_icon:3 = music;
-workspace_icon:4 = irssi;
-workspace_icon:default = 
+; workspace_icon-[0-9]+ = label;icon
+; workspace_icon-default = icon
+workspace_icon-0 = term;
+workspace_icon-1 = web;
+workspace_icon-2 = code;
+workspace_icon-3 = music;
+workspace_icon-4 = irssi;
+workspace_icon-default = 
 
 ; Available tags:
-;   <label:state> (default) - gets replaced with <label:(active|urgent|occupied|empty)>
-;   <label:mode> - gets replaced with <label:(monocle|tiled|fullscreen|floating|locked|sticky|private)>
-format = <label:state> <label:mode>
+;   <label-state> (default) - gets replaced with <label-(active|urgent|occupied|empty)>
+;   <label-mode> - gets replaced with <label-(monocle|tiled|fullscreen|floating|locked|sticky|private)>
+format = <label-state> <label-mode>
 
 ; If any of these are defined, the workspace/mode colors will get overridden
 ; with these values if the monitor is out of focus
-;label:dimmed:foreground = #555
-;label:dimmed:background = ${BAR.background}
-label:dimmed:underline = ${BAR.background}
+;label-dimmed-foreground = #555
+;label-dimmed-background = ${BAR.background}
+label-dimmed-underline = ${BAR.background}
 
 ; Available tokens:
 ;   %name%
 ;   %icon%
 ;   %index%
-; Default: %icon%  %name%
-label:active = %icon%
-label:active:foreground = #ffffff
-label:active:background = #3f3f3f
-label:active:underline = #fba922
-label:active:font = 4
-label:active:padding = 4
+; Default- %icon%  %name%
+label-active = %icon%
+label-active-foreground = #ffffff
+label-active-background = #3f3f3f
+label-active-underline = #fba922
+label-active-font = 4
+label-active-padding = 4
 
 ; Available tokens:
 ;   %name%
 ;   %icon%
 ;   %index%
-; Default: %icon%  %name%
-label:occupied = %icon%
-label:occupied:underline = #555555
-label:occupied:font = 4
-label:occupied:padding = 4
+; Default- %icon%  %name%
+label-occupied = %icon%
+label-occupied-underline = #555555
+label-occupied-font = 4
+label-occupied-padding = 4
 
 ; Available tokens:
 ;   %name%
 ;   %icon%
 ;   %index%
-; Default: %icon%  %name%
-label:urgent = %icon%
-label:urgent:foreground = #000000
-label:urgent:background = #bd2c40
-label:urgent:underline = #9b0a20
-label:urgent:font = 4
-label:urgent:padding = 4
+; Default- %icon%  %name%
+label-urgent = %icon%
+label-urgent-foreground = #000000
+label-urgent-background = #bd2c40
+label-urgent-underline = #9b0a20
+label-urgent-font = 4
+label-urgent-padding = 4
 
 ; Available tokens:
 ;   %name%
 ;   %icon%
 ;   %index%
-; Default: %icon%  %name%
-label:empty = %icon%
-label:empty:foreground = #55ffffff
-label:empty:font = 4
-label:empty:padding = 4
+; Default- %icon%  %name%
+label-empty = %icon%
+label-empty-foreground = #55ffffff
+label-empty-font = 4
+label-empty-padding = 4
 
 ; Available tokens:
 ;   None
-label:monocle = 
-label:monocle:underline = ${module/bspwm.label:active:underline}
-label:monocle:padding = 2
-;label:tiled = 
-;label:fullscreen = 
-;label:floating = 
-label:locked = 
-label:locked:foreground = #bd2c40
-label:locked:underline = ${module/bspwm.label:monocle:underline}
-label:locked:padding = ${module/bspwm.label:monocle:padding}
-label:sticky = 
-label:sticky:foreground = #fba922
-label:sticky:underline = ${module/bspwm.label:monocle:underline}
-label:sticky:padding = ${module/bspwm.label:monocle:padding}
-label:private = 
-label:private:foreground = #bd2c40
-label:private:underline = ${module/bspwm.label:monocle:underline}
-label:private:padding = ${module/bspwm.label:monocle:padding}
+label-monocle = 
+label-monocle-underline = ${module/bspwm.label-active-underline}
+label-monocle-padding = 2
+;label-tiled = 
+;label-fullscreen = 
+;label-floating = 
+label-locked = 
+label-locked-foreground = #bd2c40
+label-locked-underline = ${module/bspwm.label-monocle-underline}
+label-locked-padding = ${module/bspwm.label-monocle-padding}
+label-sticky = 
+label-sticky-foreground = #fba922
+label-sticky-underline = ${module/bspwm.label-monocle-underline}
+label-sticky-padding = ${module/bspwm.label-monocle-padding}
+label-private = 
+label-private-foreground = #bd2c40
+label-private-underline = ${module/bspwm.label-monocle-underline}
+label-private-padding = ${module/bspwm.label-monocle-padding}
 
 [module/i3]
 type = internal/i3
 
-; workspace_icon:[0-9]+ = label;icon
-; workspace_icon:default = icon
-workspace_icon:0 = 1;
-workspace_icon:1 = 2;
-workspace_icon:2 = 3;
-workspace_icon:3 = 4;
-workspace_icon:4 = 5;
-workspace_icon:default = 
+; workspace_icon-[0-9]+ = label;icon
+; workspace_icon-default = icon
+workspace_icon-0 = 1;
+workspace_icon-1 = 2;
+workspace_icon-2 = 3;
+workspace_icon-3 = 4;
+workspace_icon-4 = 5;
+workspace_icon-default = 
 
 ; Available tags:
-;   <label:state> (default) - gets replaced with <label:(focused|unfocused|visible|urgent)>
-;format = <label:state>
+;   <label-state> (default) - gets replaced with <label-(focused|unfocused|visible|urgent)>
+;format = <label-state>
 
 ; If any of these are defined, the workspace/mode colors will get overridden
 ; with these values if the monitor is out of focus
-;label:dimmed:foreground = #555
-;label:dimmed:background = ${BAR.background}
-label:dimmed:underline = ${BAR.background}
+;label-dimmed-foreground = #555
+;label-dimmed-background = ${BAR.background}
+label-dimmed-underline = ${BAR.background}
 
-; Available tokens:
+; Available tokens-
 ;   %name%
 ;   %icon%
 ;   %index%
-; Default: %icon%  %name%
-label:focused = %icon%
-label:focused:foreground = #ffffff
-label:focused:background = #3f3f3f
-label:focused:underline = #fba922
-label:focused:font = 4
-label:focused:padding = 4
+; Default- %icon%  %name%
+label-focused = %icon%
+label-focused-foreground = #ffffff
+label-focused-background = #3f3f3f
+label-focused-underline = #fba922
+label-focused-font = 4
+label-focused-padding = 4
 
-; Available tokens:
+; Available tokens-
 ;   %name%
 ;   %icon%
 ;   %index%
-; Default: %icon%  %name%
-label:unfocused = %icon%
+; Default- %icon%  %name%
+label-unfocused = %icon%
 
-; Available tokens:
+; Available tokens-
 ;   %name%
 ;   %icon%
 ;   %index%
-; Default: %icon%  %name%
-label:visible = %icon%
-label:visible:underline = #555555
-label:visible:font = 4
-label:visible:padding = 4
+; Default- %icon%  %name%
+label-visible = %icon%
+label-visible-underline = #555555
+label-visible-font = 4
+label-visible-padding = 4
 
-; Available tokens:
+; Available tokens-
 ;   %name%
 ;   %icon%
 ;   %index%
-; Default: %icon%  %name%
-label:urgent = %icon%
-label:urgent:foreground = #000000
-label:urgent:background = #bd2c40
-label:urgent:underline = #9b0a20
-label:urgent:font = 4
-label:urgent:padding = 4
+; Default- %icon%  %name%
+label-urgent = %icon%
+label-urgent-foreground = #000000
+label-urgent-background = #bd2c40
+label-urgent-underline = #9b0a20
+label-urgent-font = 4
+label-urgent-padding = 4
 
-; Available tokens:
+; Available tokens-
 ;   None
-label:monocle = 
-label:monocle:underline = ${module/bspwm.label:active:underline}
-label:monocle:padding = 2
-;label:tiled = 
-;label:fullscreen = 
-;label:floating = 
-label:locked = 
-label:locked:foreground = #bd2c40
-label:locked:underline = ${module/bspwm.label:monocle:underline}
-label:locked:padding = ${module/bspwm.label:monocle:padding}
-label:sticky = 
-label:sticky:foreground = #fba922
-label:sticky:underline = ${module/bspwm.label:monocle:underline}
-label:sticky:padding = ${module/bspwm.label:monocle:padding}
-label:private = 
-label:private:foreground = #bd2c40
-label:private:underline = ${module/bspwm.label:monocle:underline}
-label:private:padding = ${module/bspwm.label:monocle:padding}
+label-monocle = 
+label-monocle-underline = ${module/bspwm.label-active-underline}
+label-monocle-padding = 2
+;label-tiled = 
+;label-fullscreen = 
+;label-floating = 
+label-locked = 
+label-locked-foreground = #bd2c40
+label-locked-underline = ${module/bspwm.label-monocle-underline}
+label-locked-padding = ${module/bspwm.label-monocle-padding}
+label-sticky = 
+label-sticky-foreground = #fba922
+label-sticky-underline = ${module/bspwm.label-monocle-underline}
+label-sticky-padding = ${module/bspwm.label-monocle-padding}
+label-private = 
+label-private-foreground = #bd2c40
+label-private-underline = ${module/bspwm.label-monocle-underline}
+label-private-padding = ${module/bspwm.label-monocle-padding}
 
 [module/cpu]
 type = internal/cpu
@@ -449,46 +449,46 @@ interval = 0.5
 
 ; Available tags:
 ;   <label> (default)
-;   <bar:load>
-;   <ramp:load>
-;   <ramp:load_per_core>
-format = <label> <ramp:load_per_core>
+;   <bar-load>
+;   <ramp-load>
+;   <ramp-load_per_core>
+format = <label> <ramp-load_per_core>
 
-; Available tokens:
+; Available tokens-
 ;   %percentage% (default)
 label = CPU
 
-; Required if <ramp:core_load> is used
-ramp:load_per_core:0 = ▁
-ramp:load_per_core:0:font = 2
-ramp:load_per_core:0:foreground = #55aa55
-ramp:load_per_core:1 = ▂
-ramp:load_per_core:1:font = 2
-ramp:load_per_core:1:foreground = #55aa55
-ramp:load_per_core:2 = ▃
-ramp:load_per_core:2:font = 2
-ramp:load_per_core:2:foreground = #55aa55
-ramp:load_per_core:3 = ▄
-ramp:load_per_core:3:font = 2
-ramp:load_per_core:3:foreground = #55aa55
-ramp:load_per_core:4 = ▅
-ramp:load_per_core:4:font = 2
-ramp:load_per_core:4:foreground = #f5a70a
-ramp:load_per_core:5 = ▆
-ramp:load_per_core:5:font = 2
-ramp:load_per_core:5:foreground = #f5a70a
-ramp:load_per_core:6 = ▇
-ramp:load_per_core:6:font = 2
-ramp:load_per_core:6:foreground = #ff5555
-ramp:load_per_core:7 = █
-ramp:load_per_core:7:font = 2
-ramp:load_per_core:7:foreground = #ff5555
+; Required if <ramp-core_load> is used
+ramp-load_per_core-0 = ▁
+ramp-load_per_core-0-font = 2
+ramp-load_per_core-0-foreground = #55aa55
+ramp-load_per_core-1 = ▂
+ramp-load_per_core-1-font = 2
+ramp-load_per_core-1-foreground = #55aa55
+ramp-load_per_core-2 = ▃
+ramp-load_per_core-2-font = 2
+ramp-load_per_core-2-foreground = #55aa55
+ramp-load_per_core-3 = ▄
+ramp-load_per_core-3-font = 2
+ramp-load_per_core-3-foreground = #55aa55
+ramp-load_per_core-4 = ▅
+ramp-load_per_core-4-font = 2
+ramp-load_per_core-4-foreground = #f5a70a
+ramp-load_per_core-5 = ▆
+ramp-load_per_core-5-font = 2
+ramp-load_per_core-5-foreground = #f5a70a
+ramp-load_per_core-6 = ▇
+ramp-load_per_core-6-font = 2
+ramp-load_per_core-6-foreground = #ff5555
+ramp-load_per_core-7 = █
+ramp-load_per_core-7-font = 2
+ramp-load_per_core-7-foreground = #ff5555
 
-; Required if <bar:total_load> is used
-;bar:total_load:width = 10
-;bar:total_load:indicator = |
-;bar:total_load:fill = =
-;bar:total_load:empty = =
+; Required if <bar-total_load> is used
+;bar-total_load-width = 10
+;bar-total_load-indicator = |
+;bar-total_load-fill = =
+;bar-total_load-empty = =
 
 [module/date]
 type = internal/date
@@ -496,8 +496,8 @@ type = internal/date
 ; see "man date" for formatting
 ; if date_detailed is defined, clicking the area will toggle between formats
 ; if you want to use lemonbar tags here you need to use %%{...}
-date = %%{F#888}%Y-%m-%d%%{F-}  %%{F#fff}%H:%M%%{F-}
-date_detailed = %%{F#888}%A, %d %B %Y%  %%{F#fff}%H:%M%%{F#666}:%%{F#fba922}%S%%{F-}
+date = %%{F#888}%Y-%m-%d%%{F-}  %%{F#fff}%H-%M%%{F-}
+date_detailed = %%{F#888}%A, %d %B %Y  %%{F#fff}%H-%M%%{F#666}-%%{F#fba922}%S%%{F-}
 
 ; Seconds to sleep between updates
 ;interval = 1.0
@@ -505,8 +505,8 @@ date_detailed = %%{F#888}%A, %d %B %Y%  %%{F#fff}%H:%M%%{F#666}:%%{F#fba922}%S%%
 ; Available tags:
 ;   <date> (default)
 format =  <date>
-format:background = #111
-format:padding = 5
+format-background = #111
+format-padding = 5
 
 [module/memory]
 type = internal/memory
@@ -516,11 +516,11 @@ type = internal/memory
 
 ; Available tags:
 ;   <label> (default)
-;   <bar:used>
-;   <bar:free>
-format = <label> <bar:used>
+;   <bar-used>
+;   <bar-free>
+format = <label> <bar-used>
 
-; Available tokens:
+; Available tokens-
 ;   %percentage_used% (default)
 ;   %percentage_free%
 ;   %gb_used%
@@ -531,35 +531,35 @@ format = <label> <bar:used>
 ;   %mb_total%
 label = RAM
 
-; Required if <bar:used> is used
-bar:used:width = 50
-bar:used:foreground:0 = #55aa55
-bar:used:foreground:1 = #557755
-bar:used:foreground:2 = #f5a70a
-bar:used:foreground:3 = #ff5555
-bar:used:indicator = ▐
-bar:used:indicator:font = 2
-bar:used:indicator:foreground = #ddffffff
-bar:used:fill = ▐
-bar:used:fill:font = 2
-bar:used:empty = ▐
-bar:used:empty:font = 2
-bar:used:empty:foreground = #444444
+; Required if <bar-used> is used
+bar-used-width = 50
+bar-used-foreground-0 = #55aa55
+bar-used-foreground-1 = #557755
+bar-used-foreground-2 = #f5a70a
+bar-used-foreground-3 = #ff5555
+bar-used-indicator = ▐
+bar-used-indicator-font = 2
+bar-used-indicator-foreground = #ddffffff
+bar-used-fill = ▐
+bar-used-fill-font = 2
+bar-used-empty = ▐
+bar-used-empty-font = 2
+bar-used-empty-foreground = #444444
 
-; Required if <bar:free> is used
-;bar:free:width = 50
-;bar:free:foreground:0 = #ff5555
-;bar:free:foreground:1 = #f5a70a
-;bar:free:foreground:2 = #557755
-;bar:free:foreground:3 = #55aa55
-;bar:free:indicator = ▐
-;bar:free:indicator:font = 2
-;bar:free:indicator:foreground = #ddffffff
-;bar:free:fill = ▐
-;bar:free:fill:font = 2
-;bar:free:empty = ▐
-;bar:free:empty:font = 2
-;bar:free:empty:foreground = #444444
+; Required if <bar-free> is used
+;bar-free-width = 50
+;bar-free-foreground-0 = #ff5555
+;bar-free-foreground-1 = #f5a70a
+;bar-free-foreground-2 = #557755
+;bar-free-foreground-3 = #55aa55
+;bar-free-indicator = ▐
+;bar-free-indicator-font = 2
+;bar-free-indicator-foreground = #ddffffff
+;bar-free-fill = ▐
+;bar-free-fill-font = 2
+;bar-free-empty = ▐
+;bar-free-empty-font = 2
+;bar-free-empty-foreground = #444444
 
 [module/mpd]
 type = internal/mpd
@@ -568,70 +568,70 @@ type = internal/mpd
 ;interval = 0.5
 
 ; Available tags:
-;   <label:song> (default)
-;   <label:time>
-;   <bar:progress>
-;   <toggle> - gets replaced with <icon:(pause|play)>
-;   <icon:random>
-;   <icon:repeat>
-;   <icon:repeatone>
-;   <icon:prev>
-;   <icon:stop>
-;   <icon:play>
-;   <icon:pause>
-;   <icon:next>
-format:online = <icon:prev> <icon:stop> <toggle> <icon:next>  <icon:repeat> <icon:random>  <bar:progress> <label:time>  <label:song>
+;   <label-song> (default)
+;   <label-time>
+;   <bar-progress>
+;   <toggle> - gets replaced with <icon-(pause|play)>
+;   <icon-random>
+;   <icon-repeat>
+;   <icon-repeatone>
+;   <icon-prev>
+;   <icon-stop>
+;   <icon-play>
+;   <icon-pause>
+;   <icon-next>
+format-online = <icon-prev> <icon-stop> <toggle> <icon-next>  <icon-repeat> <icon-random>  <bar-progress> <label-time>  <label-song>
 
 ; Available tags:
-;   <label:offline>
-format:offline = <label:offline>
-format:offline:offset = -8
+;   <label-offline>
+format-offline = <label-offline>
+format-offline-offset = -8
 
 ; Available tokens:
 ;   %artist%
 ;   %album%
 ;   %title%
-; Default: %artist% - %title%
-;label:song =   %artist% - %title%
-;label:song:foreground = ${BAR.foreground}
+; Default- %artist% - %title%
+;label-song =   %artist% - %title%
+;label-song-foreground = ${BAR.foreground}
 
 ; Available tokens:
 ;   %elapsed%
 ;   %total%
-; Default: %elapsed% / %total%
-;label:time = %elapsed% / %total%
-label:time:foreground = #66fafafa
+; Default- %elapsed% / %total%
+;label-time = %elapsed% / %total%
+label-time-foreground = #66fafafa
 
 ; Available tokens:
 ;   None
-label:offline =  mpd is off
-label:offline:foreground = #66fafafa
+label-offline =  mpd is off
+label-offline-foreground = #66fafafa
 
-icon:play = 
-icon:pause = 
-icon:stop = 
-icon:prev = 
-icon:next = 
-icon:random = 
-icon:repeat = 
-;icon:repeatone = 🔂
+icon-play = 
+icon-pause = 
+icon-stop = 
+icon-prev = 
+icon-next = 
+icon-random = 
+icon-repeat = 
+;icon-repeatone = 🔂
 
 ; Used to display the state of random/repeat/repeatone
-toggle_on:foreground =
-toggle_off:foreground = #66fafafa
+toggle_on-foreground =
+toggle_off-foreground = #66fafafa
 
-; Required if <bar:progress> is used
-bar:progress:width = 45
-bar:progress:format = %{+u}%{+o}%fill%%{-u}%{-o}%indicator%%{+u}%{+o}%empty%%{-u}%{-o}
-bar:progress:indicator = |
-bar:progress:indicator:foreground = #ddffffff
-bar:progress:indicator:font = 3
-bar:progress:fill = █
-bar:progress:fill:foreground = #aaffffff
-bar:progress:fill:font = 3
-bar:progress:empty = █
-bar:progress:empty:font = 3
-bar:progress:empty:foreground = #44ffffff
+; Required if <bar-progress> is used
+bar-progress-width = 45
+bar-progress-format = %{+u}%{+o}%fill%%{-u}%{-o}%indicator%%{+u}%{+o}%empty%%{-u}%{-o}
+bar-progress-indicator = |
+bar-progress-indicator-foreground = #ddffffff
+bar-progress-indicator-font = 3
+bar-progress-fill = █
+bar-progress-fill-foreground = #aaffffff
+bar-progress-fill-font = 3
+bar-progress-empty = █
+bar-progress-empty-font = 3
+bar-progress-empty-foreground = #44ffffff
 
 [module/wireless-network]
 type = internal/network
@@ -649,19 +649,19 @@ interval = 3.0
 ping_interval = 3
 
 ; Available tags:
-;   <label:connected> (default)
-;   <ramp:signal>
-format:connected = <ramp:signal> <label:connected>
+;   <label-connected> (default)
+;   <ramp-signal>
+format-connected = <ramp-signal> <label-connected>
 
 ; Available tags:
-;   <label:disconnected> (default)
-;format:disconnected = <label:disconnected>
+;   <label-disconnected> (default)
+;format-disconnected = <label-disconnected>
 
 ; Available tags:
-;   <label:connected> (default)
-;   <label:packetloss>
-;   <animation:packetloss>
-;format:packetloss = <animation:packetloss> <label:connected>
+;   <label-connected> (default)
+;   <label-packetloss>
+;   <animation-packetloss>
+;format-packetloss = <animation-packetloss> <label-connected>
 
 ; Available tokens:
 ;   %ifname%    [wireless+wired]
@@ -670,14 +670,14 @@ format:connected = <ramp:signal> <label:connected>
 ;   %signal%    [wireless]
 ;   %linkspeed% [wired]
 ; Default: %ifname% %local_ip%
-label:connected = %essid%
-label:connected:foreground = #eefafafa
+label-connected = %essid%
+label-connected-foreground = #eefafafa
 
 ; Available tokens:
 ;   %ifname%    [wireless+wired]
 ; Default: (none)
-label:disconnected =    not connected
-label:disconnected:foreground = #66ffffff
+label-disconnected =    not connected
+label-disconnected-foreground = #66ffffff
 
 ; Available tokens:
 ;   %ifname%    [wireless+wired]
@@ -686,27 +686,25 @@ label:disconnected:foreground = #66ffffff
 ;   %signal%    [wireless]
 ;   %linkspeed% [wired]
 ; Default: (none)
-;label:packetloss = %essid%
-;label:packetloss:foreground = #eefafafa
+;label-packetloss = %essid%
+;label-packetloss-foreground = #eefafafa
 
-; Required if <ramp:signal> is used
-ramp:signal:0 = 
-ramp:signal:0:foreground = #33ffffff
-ramp:signal:1 = 
-ramp:signal:1:foreground = #66ffffff
-ramp:signal:2 = 
-ramp:signal:2:foreground = #99ffffff
-ramp:signal:3 = 
-ramp:signal:3:foreground = #ccffffff
-ramp:signal:4 = 
-ramp:signal:4:foreground = #ffffffff
+ramp-signal-0 = 
+ramp-signal-0-foreground = #33ffffff
+ramp-signal-1 = 
+ramp-signal-1-foreground = #66ffffff
+ramp-signal-2 = 
+ramp-signal-2-foreground = #99ffffff
+ramp-signal-3 = 
+ramp-signal-3-foreground = #ccffffff
+ramp-signal-4 = 
+ramp-signal-4-foreground = #ffffffff
 
-; Required if <animation:packetloss> is used
-animation:packetloss:0 = 
-animation:packetloss:0:foreground = #ffa64c
-animation:packetloss:1 = 
-animation:packetloss:1:foreground = ${bar/top.foreground}
-animation:packetloss:framerate_ms = 500
+animation-packetloss-0 = 
+animation-packetloss-0-foreground = #ffa64c
+animation-packetloss-1 = 
+animation-packetloss-1-foreground = ${bar/top.foreground}
+animation-packetloss-framerate_ms = 500
 
 [module/wired-network]
 type = internal/network
@@ -718,22 +716,22 @@ interval = 2.0
 
 ; Seconds to sleep between connectivity tests
 ; A value of 0 disables the testing
-; Default: 0
+; Default- 0
 ;connectivity_test_interval = 0
 
 ; Available tags:
-;   <label:connected> (default)
-;   <ramp:signal>
-;format:connected = <label:connected>
+;   <label-connected> (default)
+;   <ramp-signal>
+;format-connected = <label-connected>
 
 ; Available tags:
-;   <label:disconnected> (default)
-;format:disconnected = <label:disconnected>
+;   <label-disconnected> (default)
+;format-disconnected = <label-disconnected>
 
 ; Available tags:
-;   <label:packetloss> (default)
-;   <animation:packetloss>
-; format:packetloss = <animation:packetloss> <label:packetloss>
+;   <label-packetloss> (default)
+;   <animation-packetloss>
+; format-packetloss = <animation-packetloss> <label-packetloss>
 
 ; Available tokens:
 ;   %ifname%    [wireless+wired]
@@ -741,15 +739,15 @@ interval = 2.0
 ;   %essid%     [wireless]
 ;   %signal%    [wireless]
 ;   %linkspeed% [wired]
-; Default: %ifname% %local_ip%
-label:connected =    %{T3}%local_ip%%{T-}
-;label:connected:foreground = #eefafafa
+; Default- %ifname% %local_ip%
+label-connected =    %{T3}%local_ip%%{T-}
+;label-connected-foreground = #eefafafa
 
 ; Available tokens:
 ;   %ifname%    [wireless+wired]
-; Default: (none)
-;label:disconnected =    not connected
-;label:disconnected:foreground = #66ffffff
+; Default- (none)
+;label-disconnected =    not connected
+;label-disconnected-foreground = #66ffffff
 
 ; Available tokens:
 ;   %ifname%    [wireless+wired]
@@ -757,10 +755,10 @@ label:connected =    %{T3}%local_ip%%{T-}
 ;   %essid%     [wireless]
 ;   %signal%    [wireless]
 ;   %linkspeed% [wired]
-; Default: %ifname% %local_ip%
+; Default- %ifname% %local_ip%
 ; ------------------------- NOT ACTIVATED (Needs more testing)
-;label:packetloss = %essid%
-;label:packetloss:foreground = #eefafafa
+;label-packetloss = %essid%
+;label-packetloss-foreground = #eefafafa
 
 [module/rtorrent]
 type = internal/rtorrent
@@ -772,28 +770,28 @@ title_maxlen = 30
 
 ; Available tags:
 ;   <label> (default)
-;   <bar:progress>
+;   <bar-progress>
 ;format = <label>
 
 ; Available tokens:
 ;   %title%
 ;   %percentage%
-; Default: %label% (%percentage%)
+; Default- %label% (%percentage%)
 label = %{F#fba922}%{F-} %{F#eefafafa}%title% %percentage%%{F-}
-;label:foreground = #eefafafa
+;label-foreground = #eefafafa
 
-; Required if <bar:progress> is used
-;bar:progress:width = 10
-;bar:progress:format = %{+u}%{+o}%fill%%{-u}%{-o}%indicator%%{+u}%{+o}%empty%%{-u}%{-o}
-;bar:progress:indicator = |
-;bar:progress:indicator:foreground = ${BAR.foreground}
-;bar:progress:indicator:font = 2
-;bar:progress:fill = █
-;bar:progress:fill:foreground = #5a5
-;bar:progress:fill:font = 2
-;bar:progress:empty = █
-;bar:progress:empty:foreground = #555
-;bar:progress:empty:font = 2
+; Required if <bar-progress> is used
+;bar-progress-width = 10
+;bar-progress-format = %{+u}%{+o}%fill%%{-u}%{-o}%indicator%%{+u}%{+o}%empty%%{-u}%{-o}
+;bar-progress-indicator = |
+;bar-progress-indicator-foreground = ${BAR.foreground}
+;bar-progress-indicator-font = 2
+;bar-progress-fill = █
+;bar-progress-fill-foreground = #5a5
+;bar-progress-fill-font = 2
+;bar-progress-empty = █
+;bar-progress-empty-foreground = #555
+;bar-progress-empty-font = 2
 
 [module/volume]
 type = internal/volume
@@ -808,46 +806,46 @@ headphone_mixer = Headphone
 headphone_control_numid = 9
 
 ; Available tags:
-;   <label:volume> (default)
-;   <ramp:volume>
-;   <bar:volume>
-format:volume = <ramp:volume> <label:volume>
+;   <label-volume> (default)
+;   <ramp-volume>
+;   <bar-volume>
+format-volume = <ramp-volume> <label-volume>
 
 ; Available tags:
-;   <label:muted> (default)
-;   <ramp:volume>
-;   <bar:volume>
-;format:muted = <label:muted>
+;   <label-muted> (default)
+;   <ramp-volume>
+;   <bar-volume>
+;format-muted = <label-muted>
 
 ; Available tokens:
 ;   %percentage% (default)
-;label:volume = %percentage%
-label:volume:foreground = #ffffff
+;label-volume = %percentage%
+label-volume-foreground = #ffffff
 
 ; Available tokens:
 ;   %percentage% (default)
-label:muted =   muted
-label:muted:foreground = #66ffffff
+label-muted =   muted
+label-muted-foreground = #66ffffff
 
-; Required if <ramp:volume> is used
-ramp:volume:0 = 
-ramp:volume:0:foreground = #99ffffff
-ramp:volume:1 = 
-ramp:volume:1:foreground = #bbffffff
-ramp:volume:2 = 
-ramp:volume:2:foreground = #ddffffff
-ramp:volume:3 = 
-ramp:volume:3:foreground = #ffffffff
+; Required if <ramp-volume> is used
+ramp-volume-0 = 
+ramp-volume-0-foreground = #99ffffff
+ramp-volume-1 = 
+ramp-volume-1-foreground = #bbffffff
+ramp-volume-2 = 
+ramp-volume-2-foreground = #ddffffff
+ramp-volume-3 = 
+ramp-volume-3-foreground = #ffffffff
 
-; Required if <bar:capacity> is used
-bar:volume:width = 10
-bar:volume:format = %{+u}%{+o}%fill%%empty%%{-u}%{-o}
-bar:volume:fill = █
-bar:volume:fill:foreground = #ddffffff
-bar:volume:fill:font = 3
-bar:volume:empty = █
-bar:volume:empty:font = 3
-bar:volume:empty:foreground = #44ffffff
+; Required if <bar-capacity> is used
+bar-volume-width = 10
+bar-volume-format = %{+u}%{+o}%fill%%empty%%{-u}%{-o}
+bar-volume-fill = █
+bar-volume-fill-foreground = #ddffffff
+bar-volume-fill-font = 3
+bar-volume-empty = █
+bar-volume-empty-font = 3
+bar-volume-empty-foreground = #44ffffff
 
 
 
@@ -855,64 +853,64 @@ bar:volume:empty:foreground = #44ffffff
 type = custom/menu
 
 ; Available tags:
-;   <label:toggle> (default) - gets replaced with <label:(open|close)>
+;   <label-toggle> (default) - gets replaced with <label-(open|close)>
 ;   <menu> (default)
-;format = <label:toggle> <menu>
-format:background = #111111
-format:padding = 3
+;format = <label-toggle> <menu>
+format-background = #111111
+format-padding = 3
 
-label:open = 
-label:close = 
+label-open = 
+label-close = 
 
-; "menu:LEVEL:N" has the same properties as "label:NAME" with
+; "menu-LEVEL-N" has the same properties as "label-NAME" with
 ; the additional "exec" property
 ;
 ; Available exec commands:
-;   menu_open:LEVEL
+;   menu_open-LEVEL
 ;   menu_close
 ; Other commands will be executed using "/usr/bin/env sh -c $COMMAND"
 
-menu:0:0 = Terminate WM
-menu:0:0:foreground = #fba922
-menu:0:0:exec = bspc quit -1
-menu:0:1 = Reboot
-menu:0:1:foreground = #fba922
-menu:0:1:exec = menu_open:1
-menu:0:2 = Power off
-menu:0:2:foreground = #fba922
-menu:0:2:exec = menu_open:2
+menu-0-0 = Terminate WM
+menu-0-0-foreground = #fba922
+menu-0-0-exec = bspc quit -1
+menu-0-1 = Reboot
+menu-0-1-foreground = #fba922
+menu-0-1-exec = menu_open-1
+menu-0-2 = Power off
+menu-0-2-foreground = #fba922
+menu-0-2-exec = menu_open-2
 
-menu:1:0 = Cancel
-menu:1:0:foreground = #fba922
-menu:1:0:exec = menu_open:0
-menu:1:1 = Reboot
-menu:1:1:foreground = #fba922
-menu:1:1:exec = sudo reboot
+menu-1-0 = Cancel
+menu-1-0-foreground = #fba922
+menu-1-0-exec = menu_open-0
+menu-1-1 = Reboot
+menu-1-1-foreground = #fba922
+menu-1-1-exec = sudo reboot
 
-menu:2:0 = Power off
-menu:2:0:foreground = #fba922
-menu:2:0:exec = sudo poweroff
-menu:2:1 = Cancel
-menu:2:1:foreground = #fba922
-menu:2:1:exec = menu_open:0
+menu-2-0 = Power off
+menu-2-0-foreground = #fba922
+menu-2-0-exec = sudo poweroff
+menu-2-1 = Cancel
+menu-2-1-foreground = #fba922
+menu-2-1-exec = menu_open-0
 
 [module/text-example]
 type = custom/text
 
-; "content" has the same properties as "format:NAME"
+; "content" has the same properties as "format-NAME"
 content = 
-content:background = #000
-content:foreground = #fff
-content:padding = 4
+content-background = #000
+content-foreground = #fff
+content-padding = 4
 
-; "click:(left|middle|right)" will be executed using "/usr/bin/env sh -c $COMMAND"
-click:left = echo left
-click:middle = echo middle
-click:right = echo right
+; "click-(left|middle|right)" will be executed using "/usr/bin/env sh -c $COMMAND"
+click-left = echo left
+click-middle = echo middle
+click-right = echo right
 
-; "scroll:(up|down)" will be executed using "/usr/bin/env sh -c $COMMAND"
-scroll:up = echo scroll up
-scroll:down = echo scroll down
+; "scroll-(up|down)" will be executed using "/usr/bin/env sh -c $COMMAND"
+scroll-up = echo scroll up
+scroll-down = echo scroll down
 
 [module/script-example]
 type = custom/script
@@ -929,24 +927,24 @@ interval = 0.5
 ; Available tags:
 ;   <output> (default)
 ;format = <output>
-format:background = #999
-format:foreground = #000
-format:padding = 4
+format-background = #999
+format-foreground = #000
+format-padding = 4
 
 ; Available tokens:
 ;   %counter%
 ;
-; "click:(left|middle|right)" will be executed using "/usr/bin/env sh -c [command]"
-click:left = echo left %counter%
-click:middle = echo middle %counter%
-click:right = echo right %counter%
+; "click-(left|middle|right)" will be executed using "/usr/bin/env sh -c [command]"
+click-left = echo left %counter%
+click-middle = echo middle %counter%
+click-right = echo right %counter%
 
 ; Available tokens:
 ;   %counter%
 ;
-; "scroll:(up|down)" will be executed using "/usr/bin/env sh -c [command]"
-scroll:up = echo scroll up %counter%
-scroll:down = echo scroll down %counter%
+; "scroll-(up|down)" will be executed using "/usr/bin/env sh -c [command]"
+scroll-up = echo scroll up %counter%
+scroll-down = echo scroll down %counter%
 
 [module/clock]
 type = internal/date

--- a/examples/config
+++ b/examples/config
@@ -11,7 +11,8 @@ height = 25
 bottom = true
 dock = false
 
-background = #00ffffff
+background = ["one"]
+;background = #00ffffff
 foreground = #fff
 
 lineheight = 1
@@ -20,42 +21,42 @@ padding_right = 1
 module_margin_left = 0
 module_margin_right = 0
 
-font:0 = sans:size=8;0
-font:1 = font awesome:size=10:weight=heavy;0
+font-0 = sans:size=8;0
+font-1 = font awesome:size=10:weight=heavy;0
 
-modules:left = label
-modules:right = cpu ram clock
+modules-left = label
+modules-right = cpu ram clock
 
 [module/label]
 type = custom/text
 content = Lemonbuddy example
-content:background = #af2031
-content:underline = #cf4253
-content:overline = #cf4253
-content:padding = 2
+content-background = #af2031
+content-underline = #cf4253
+content-overline = #cf4253
+content-padding = 2
 
 [module/cpu]
 type = internal/cpu
 label = CPU: %percentage%
-format:background = #c42
-format:underline = #f75
-format:overline = #f75
-format:padding = 2
+format-background = #c42
+format-underline = #f75
+format-overline = #f75
+format-padding = 2
 
 [module/ram]
 type = internal/memory
 label = RAM: %percentage_used%
-format:background = #42c
-format:underline = #75f
-format:overline = #75f
-format:padding = 2
+format-background = #42c
+format-underline = #75f
+format-overline = #75f
+format-padding = 2
 
 [module/clock]
 type = internal/date
 date = %Y-%m-%d %H:%M
-format:background = #493
-format:underline = #7a6
-format:overline = #7a6
-format:padding = 2
+format-background = #493
+format-underline = #7a6
+format-overline = #7a6
+format-padding = 2
 
 ; vim:ft=dosini

--- a/examples/config.bspwm
+++ b/examples/config.bspwm
@@ -20,52 +20,52 @@ padding_right = 1
 module_margin_left = 0
 module_margin_right = 0
 
-font:0 = sans:size=8;0
-font:1 = fontawesome:size=10:weight=heavy;0
+font-0 = sans:size=8;0
+font-1 = fontawesome:size=10:weight=heavy;0
 
-modules:left = label
-modules:center = bspwm
-modules:right = cpu ram clock
+modules-left = label
+modules-center = bspwm
+modules-right = cpu ram clock
 
 [module/label]
 type = custom/text
 content = Lemonbuddy example
-content:background = #af2031
-content:underline = #cf4253
-content:overline = #cf4253
-content:padding = 2
+content-background = #af2031
+content-underline = #cf4253
+content-overline = #cf4253
+content-padding = 2
 
 [module/bspwm]
 type = internal/bspwm
-label:active = 
-label:active:padding = 1
-label:occupied = 
-label:occupied:padding = 1
-label:empty = 
-label:empty:padding = 1
+label-active = 
+label-active-padding = 1
+label-occupied = 
+label-occupied-padding = 1
+label-empty = 
+label-empty-padding = 1
 
 [module/cpu]
 type = internal/cpu
 label = CPU: %percentage%
-format:background = #c42
-format:underline = #f75
-format:overline = #f75
-format:padding = 2
+format-background = #c42
+format-underline = #f75
+format-overline = #f75
+format-padding = 2
 
 [module/ram]
 type = internal/memory
 label = RAM: %percentage_used%
-format:background = #42c
-format:underline = #75f
-format:overline = #75f
-format:padding = 2
+format-background = #42c
+format-underline = #75f
+format-overline = #75f
+format-padding = 2
 
 [module/clock]
 type = internal/date
 date = %Y-%m-%d %H:%M
-format:background = #493
-format:underline = #7a6
-format:overline = #7a6
-format:padding = 2
+format-background = #493
+format-underline = #7a6
+format-overline = #7a6
+format-padding = 2
 
 ; vim:ft=dosini

--- a/examples/config.i3
+++ b/examples/config.i3
@@ -20,52 +20,52 @@ padding_right = 1
 module_margin_left = 0
 module_margin_right = 0
 
-font:0 = sans:size=8;0
-font:1 = fontawesome:size=10:weight=heavy;0
+font-0 = sans:size=8;0
+font-1 = fontawesome:size=10:weight=heavy;0
 
-modules:left = label
-modules:center = i3
-modules:right = cpu ram clock
+modules-left = label
+modules-center = i3
+modules-right = cpu ram clock
 
 [module/label]
 type = custom/text
 content = Lemonbuddy example
-content:background = #af2031
-content:underline = #cf4253
-content:overline = #cf4253
-content:padding = 2
+content-background = #af2031
+content-underline = #cf4253
+content-overline = #cf4253
+content-padding = 2
 
 [module/i3]
 type = internal/i3
-label:focused = 
-label:focused:padding = 1
-label:unfocused = 
-label:unfocused:padding = 1
-label:visible = 
-label:visible:padding = 1
+label-focused = 
+label-focused-padding = 1
+label-unfocused = 
+label-unfocused-padding = 1
+label-visible = 
+label-visible-padding = 1
 
 [module/cpu]
 type = internal/cpu
 label = CPU: %percentage%
-format:background = #c42
-format:underline = #f75
-format:overline = #f75
-format:padding = 2
+format-background = #c42
+format-underline = #f75
+format-overline = #f75
+format-padding = 2
 
 [module/ram]
 type = internal/memory
 label = RAM: %percentage_used%
-format:background = #42c
-format:underline = #75f
-format:overline = #75f
-format:padding = 2
+format-background = #42c
+format-underline = #75f
+format-overline = #75f
+format-padding = 2
 
 [module/clock]
 type = internal/date
 date = %Y-%m-%d %H:%M
-format:background = #493
-format:underline = #7a6
-format:overline = #7a6
-format:padding = 2
+format-background = #493
+format-underline = #7a6
+format-overline = #7a6
+format-padding = 2
 
 ; vim:ft=dosini

--- a/include/modules/base.hpp
+++ b/include/modules/base.hpp
@@ -87,14 +87,14 @@ class ModuleFormatter
       auto format = std::make_unique<Format>();
 
       format->value = config::get<std::string>(this->module_name, name, fallback);
-      format->fg = config::get<std::string>(this->module_name, name +":foreground", "");
-      format->bg = config::get<std::string>(this->module_name, name +":background", "");
-      format->ul = config::get<std::string>(this->module_name, name +":underline", "");
-      format->ol = config::get<std::string>(this->module_name, name +":overline", "");
-      format->spacing = config::get<int>(this->module_name, name +":spacing", DEFAULT_SPACING);
-      format->padding = config::get<int>(this->module_name, name +":padding", 0);
-      format->margin = config::get<int>(this->module_name, name +":margin", 0);
-      format->offset = config::get<int>(this->module_name, name +":offset", 0);
+      format->fg = config::get<std::string>(this->module_name, name +"-foreground", "");
+      format->bg = config::get<std::string>(this->module_name, name +"-background", "");
+      format->ul = config::get<std::string>(this->module_name, name +"-underline", "");
+      format->ol = config::get<std::string>(this->module_name, name +"-overline", "");
+      format->spacing = config::get<int>(this->module_name, name +"-spacing", DEFAULT_SPACING);
+      format->padding = config::get<int>(this->module_name, name +"-padding", 0);
+      format->margin = config::get<int>(this->module_name, name +"-margin", 0);
+      format->offset = config::get<int>(this->module_name, name +"-offset", 0);
       format->tags.swap(tags);
 
       for (auto &&tag : string::split(format->value, ' ')) {

--- a/include/modules/battery.hpp
+++ b/include/modules/battery.hpp
@@ -20,16 +20,16 @@ namespace modules
       static const int STATE_FULL = 4;
 
     protected:
-      static constexpr auto FORMAT_CHARGING = "format:charging";
-      static constexpr auto FORMAT_DISCHARGING = "format:discharging";
-      static constexpr auto FORMAT_FULL = "format:full";
+      static constexpr auto FORMAT_CHARGING = "format-charging";
+      static constexpr auto FORMAT_DISCHARGING = "format-discharging";
+      static constexpr auto FORMAT_FULL = "format-full";
 
-      static constexpr auto TAG_ANIMATION_CHARGING = "<animation:charging>";
-      static constexpr auto TAG_BAR_CAPACITY = "<bar:capacity>";
-      static constexpr auto TAG_RAMP_CAPACITY = "<ramp:capacity>";
-      static constexpr auto TAG_LABEL_CHARGING = "<label:charging>";
-      static constexpr auto TAG_LABEL_DISCHARGING = "<label:discharging>";
-      static constexpr auto TAG_LABEL_FULL = "<label:full>";
+      static constexpr auto TAG_ANIMATION_CHARGING = "<animation-charging>";
+      static constexpr auto TAG_BAR_CAPACITY = "<bar-capacity>";
+      static constexpr auto TAG_RAMP_CAPACITY = "<ramp-capacity>";
+      static constexpr auto TAG_LABEL_CHARGING = "<label-charging>";
+      static constexpr auto TAG_LABEL_DISCHARGING = "<label-discharging>";
+      static constexpr auto TAG_LABEL_FULL = "<label-full>";
 
       std::unique_ptr<drawtypes::Animation> animation_charging;
       std::unique_ptr<drawtypes::Ramp> ramp_capacity;

--- a/include/modules/bspwm.hpp
+++ b/include/modules/bspwm.hpp
@@ -48,8 +48,8 @@ namespace modules
 
   DefineModule(BspwmModule, EventModule)
   {
-    static constexpr auto TAG_LABEL_STATE = "<label:state>";
-    static constexpr auto TAG_LABEL_MODE = "<label:mode>";
+    static constexpr auto TAG_LABEL_STATE = "<label-state>";
+    static constexpr auto TAG_LABEL_MODE = "<label-mode>";
 
     static constexpr auto EVENT_CLICK = "bwm";
 

--- a/include/modules/cpu.hpp
+++ b/include/modules/cpu.hpp
@@ -23,9 +23,9 @@ namespace modules
   DefineModule(CpuModule, TimerModule)
   {
     static constexpr auto TAG_LABEL = "<label>";
-    static constexpr auto TAG_BAR_LOAD = "<bar:load>";
-    static constexpr auto TAG_RAMP_LOAD = "<ramp:load>";
-    static constexpr auto TAG_RAMP_LOAD_PER_CORE = "<ramp:load_per_core>";
+    static constexpr auto TAG_BAR_LOAD = "<bar-load>";
+    static constexpr auto TAG_RAMP_LOAD = "<ramp-load>";
+    static constexpr auto TAG_RAMP_LOAD_PER_CORE = "<ramp-load_per_core>";
 
     std::vector<std::unique_ptr<CpuTime>> cpu_times;
     std::vector<std::unique_ptr<CpuTime>> prev_cpu_times;

--- a/include/modules/i3.hpp
+++ b/include/modules/i3.hpp
@@ -42,7 +42,7 @@ namespace modules
 
   DefineModule(i3Module, EventModule)
   {
-    static constexpr auto TAG_LABEL_STATE = "<label:state>";
+    static constexpr auto TAG_LABEL_STATE = "<label-state>";
 
     static constexpr auto EVENT_CLICK = "i3";
 

--- a/include/modules/memory.hpp
+++ b/include/modules/memory.hpp
@@ -12,8 +12,8 @@ namespace modules
   DefineModule(MemoryModule, TimerModule)
   {
     static constexpr auto TAG_LABEL = "<label>";
-    static constexpr auto TAG_BAR_USED = "<bar:used>";
-    static constexpr auto TAG_BAR_FREE = "<bar:free>";
+    static constexpr auto TAG_BAR_USED = "<bar-used>";
+    static constexpr auto TAG_BAR_FREE = "<bar-free>";
 
     std::unique_ptr<drawtypes::Bar> bar_used;
     std::unique_ptr<drawtypes::Bar> bar_free;

--- a/include/modules/menu.hpp
+++ b/include/modules/menu.hpp
@@ -17,10 +17,10 @@ namespace modules
 
   DefineModule(MenuModule, StaticModule)
   {
-    static constexpr auto TAG_LABEL_TOGGLE = "<label:toggle>";
+    static constexpr auto TAG_LABEL_TOGGLE = "<label-toggle>";
     static constexpr auto TAG_MENU = "<menu>";
 
-    static constexpr auto EVENT_MENU_OPEN = "menu_open:";
+    static constexpr auto EVENT_MENU_OPEN = "menu_open-";
     static constexpr auto EVENT_MENU_CLOSE = "menu_close";
 
     std::mutex output_mtx;

--- a/include/modules/mpd.hpp
+++ b/include/modules/mpd.hpp
@@ -13,22 +13,22 @@ namespace modules
     static const int PROGRESSBAR_THREAD_SYNC_COUNT = 10;
     const std::chrono::duration<double> PROGRESSBAR_THREAD_INTERVAL = 1s;
 
-    static constexpr auto FORMAT_ONLINE = "format:online";
-    static constexpr auto TAG_BAR_PROGRESS = "<bar:progress>";
+    static constexpr auto FORMAT_ONLINE = "format-online";
+    static constexpr auto TAG_BAR_PROGRESS = "<bar-progress>";
     static constexpr auto TAG_TOGGLE = "<toggle>";
-    static constexpr auto TAG_LABEL_SONG = "<label:song>";
-    static constexpr auto TAG_LABEL_TIME = "<label:time>";
-    static constexpr auto TAG_ICON_RANDOM = "<icon:random>";
-    static constexpr auto TAG_ICON_REPEAT = "<icon:repeat>";
-    static constexpr auto TAG_ICON_REPEAT_ONE = "<icon:repeatone>";
-    static constexpr auto TAG_ICON_PREV = "<icon:prev>";
-    static constexpr auto TAG_ICON_STOP = "<icon:stop>";
-    static constexpr auto TAG_ICON_PLAY = "<icon:play>";
-    static constexpr auto TAG_ICON_PAUSE = "<icon:pause>";
-    static constexpr auto TAG_ICON_NEXT = "<icon:next>";
+    static constexpr auto TAG_LABEL_SONG = "<label-song>";
+    static constexpr auto TAG_LABEL_TIME = "<label-time>";
+    static constexpr auto TAG_ICON_RANDOM = "<icon-random>";
+    static constexpr auto TAG_ICON_REPEAT = "<icon-repeat>";
+    static constexpr auto TAG_ICON_REPEAT_ONE = "<icon-repeatone>";
+    static constexpr auto TAG_ICON_PREV = "<icon-prev>";
+    static constexpr auto TAG_ICON_STOP = "<icon-stop>";
+    static constexpr auto TAG_ICON_PLAY = "<icon-play>";
+    static constexpr auto TAG_ICON_PAUSE = "<icon-pause>";
+    static constexpr auto TAG_ICON_NEXT = "<icon-next>";
 
-    static constexpr auto FORMAT_OFFLINE = "format:offline";
-    static constexpr auto TAG_LABEL_OFFLINE = "<label:offline>";
+    static constexpr auto FORMAT_OFFLINE = "format-offline";
+    static constexpr auto TAG_LABEL_OFFLINE = "<label-offline>";
 
     static constexpr auto EVENT_PLAY = "mpdplay";
     static constexpr auto EVENT_PAUSE = "mpdpause";

--- a/include/modules/network.hpp
+++ b/include/modules/network.hpp
@@ -17,15 +17,15 @@ namespace modules
 {
   DefineModule(NetworkModule, TimerModule)
   {
-    static constexpr auto FORMAT_CONNECTED = "format:connected";
-    static constexpr auto FORMAT_PACKETLOSS = "format:packetloss";
-    static constexpr auto FORMAT_DISCONNECTED = "format:disconnected";
+    static constexpr auto FORMAT_CONNECTED = "format-connected";
+    static constexpr auto FORMAT_PACKETLOSS = "format-packetloss";
+    static constexpr auto FORMAT_DISCONNECTED = "format-disconnected";
 
-    static constexpr auto TAG_RAMP_SIGNAL = "<ramp:signal>";
-    static constexpr auto TAG_LABEL_CONNECTED = "<label:connected>";
-    static constexpr auto TAG_LABEL_DISCONNECTED = "<label:disconnected>";
-    static constexpr auto TAG_LABEL_PACKETLOSS = "<label:packetloss>";
-    static constexpr auto TAG_ANIMATION_PACKETLOSS = "<animation:packetloss>";
+    static constexpr auto TAG_RAMP_SIGNAL = "<ramp-signal>";
+    static constexpr auto TAG_LABEL_CONNECTED = "<label-connected>";
+    static constexpr auto TAG_LABEL_DISCONNECTED = "<label-disconnected>";
+    static constexpr auto TAG_LABEL_PACKETLOSS = "<label-packetloss>";
+    static constexpr auto TAG_ANIMATION_PACKETLOSS = "<animation-packetloss>";
 
     std::unique_ptr<net::WiredNetwork> wired_network;
     std::unique_ptr<net::WirelessNetwork> wireless_network;

--- a/include/modules/torrent.hpp
+++ b/include/modules/torrent.hpp
@@ -19,7 +19,7 @@ namespace modules
   DefineModule(TorrentModule, InotifyModule)
   {
     static constexpr auto TAG_LABEL = "<label>";
-    static constexpr auto TAG_BAR_PROGRESS = "<bar:progress>";
+    static constexpr auto TAG_BAR_PROGRESS = "<bar-progress>";
 
     std::vector<std::unique_ptr<Torrent>> torrents;
     std::unique_ptr<drawtypes::Label> label;

--- a/include/modules/volume.hpp
+++ b/include/modules/volume.hpp
@@ -11,13 +11,13 @@ namespace modules
 {
   DefineModule(VolumeModule, EventModule)
   {
-    static constexpr auto FORMAT_VOLUME = "format:volume";
-    static constexpr auto FORMAT_MUTED = "format:muted";
+    static constexpr auto FORMAT_VOLUME = "format-volume";
+    static constexpr auto FORMAT_MUTED = "format-muted";
 
-    static constexpr auto TAG_RAMP_VOLUME = "<ramp:volume>";
-    static constexpr auto TAG_BAR_VOLUME = "<bar:volume>";
-    static constexpr auto TAG_LABEL_VOLUME = "<label:volume>";
-    static constexpr auto TAG_LABEL_MUTED = "<label:muted>";
+    static constexpr auto TAG_RAMP_VOLUME = "<ramp-volume>";
+    static constexpr auto TAG_BAR_VOLUME = "<bar-volume>";
+    static constexpr auto TAG_LABEL_VOLUME = "<label-volume>";
+    static constexpr auto TAG_LABEL_MUTED = "<label-muted>";
 
     static constexpr auto EVENT_VOLUME_UP = "volup";
     static constexpr auto EVENT_VOLUME_DOWN = "voldown";

--- a/include/utils/config.hpp
+++ b/include/utils/config.hpp
@@ -94,13 +94,13 @@ namespace config
     std::vector<T> vec;
     boost::optional<T> value;
 
-    while ((value = get_tree().get_optional<T>(build_path(section, key) + ":"+ std::to_string(vec.size()))) != boost::none) {
-      auto str_val = get_tree().get<std::string>(build_path(section, key) + ":"+ std::to_string(vec.size()));
+    while ((value = get_tree().get_optional<T>(build_path(section, key) + "-"+ std::to_string(vec.size()))) != boost::none) {
+      auto str_val = get_tree().get<std::string>(build_path(section, key) + "-"+ std::to_string(vec.size()));
       vec.emplace_back(dereference_var<T>(section, key, str_val, value.get()));
     }
 
     if (vec.empty())
-      throw MissingListValueException("Missing property \""+ key + ":0\" in section ["+ section +"]");
+      throw MissingListValueException("Missing property \""+ key + "-0\" in section ["+ section +"]");
 
     return vec;
   }
@@ -113,8 +113,8 @@ namespace config
     std::vector<T> vec;
     boost::optional<T> value;
 
-    while ((value = get_tree().get_optional<T>(build_path(section, key) + ":"+ std::to_string(vec.size()))) != boost::none) {
-      auto str_val = get_tree().get<std::string>(build_path(section, key) + ":"+ std::to_string(vec.size()));
+    while ((value = get_tree().get_optional<T>(build_path(section, key) + "-"+ std::to_string(vec.size()))) != boost::none) {
+      auto str_val = get_tree().get<std::string>(build_path(section, key) + "-"+ std::to_string(vec.size()));
       vec.emplace_back(dereference_var<T>(section, key, str_val, value.get()));
     }
 

--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -189,9 +189,9 @@ void Bar::load()
     }
   };
 
-  add_modules(config::get<std::string>(this->config_path, "modules:left", ""), this->mod_left);
-  add_modules(config::get<std::string>(this->config_path, "modules:center", ""), this->mod_center);
-  add_modules(config::get<std::string>(this->config_path, "modules:right", ""), this->mod_right);
+  add_modules(config::get<std::string>(this->config_path, "modules-left", ""), this->mod_left);
+  add_modules(config::get<std::string>(this->config_path, "modules-center", ""), this->mod_center);
+  add_modules(config::get<std::string>(this->config_path, "modules-right", ""), this->mod_right);
 
   if (this->mod_left.empty() && this->mod_center.empty() && this->mod_right.empty())
     throw ConfigurationError("The bar does not contain any modules...");

--- a/src/drawtypes/animation.cpp
+++ b/src/drawtypes/animation.cpp
@@ -21,11 +21,11 @@ namespace drawtypes
 
     repeat(n_frames)
     {
-      auto anim = animation_name +":"+ std::to_string(repeat_i_rev(n_frames));
+      auto anim = animation_name +"-"+ std::to_string(repeat_i_rev(n_frames));
       vec.emplace_back(std::unique_ptr<Icon> { get_optional_config_icon(config_path, anim, frames[n_frames - repeat_i - 1]) });
     }
 
-    auto framerate = config::get<int>(config_path, animation_name +":framerate_ms", 1000);
+    auto framerate = config::get<int>(config_path, animation_name +"-framerate_ms", 1000);
 
     return std::unique_ptr<Animation> { new Animation(std::move(vec), framerate) };
   }

--- a/src/drawtypes/bar.cpp
+++ b/src/drawtypes/bar.cpp
@@ -11,19 +11,19 @@ namespace drawtypes
   {
     std::unique_ptr<Bar> bar;
 
-    auto width = config::get<int>(config_path, bar_name +":width");
-    auto format = config::get<std::string>(config_path, bar_name +":format", "%fill%%indicator%%empty%");
+    auto width = config::get<int>(config_path, bar_name +"-width");
+    auto format = config::get<std::string>(config_path, bar_name +"-format", "%fill%%indicator%%empty%");
 
     if (format.empty())
       bar = std::make_unique<Bar>(width, lazy_builder_closing);
     else
       bar = std::make_unique<Bar>(width, format, lazy_builder_closing);
 
-    bar->set_gradient(config::get<bool>(config_path, bar_name +":gradient", true));
-    bar->set_colors(config::get_list<std::string>(config_path, bar_name +":foreground", {}));
-    bar->set_indicator(get_config_icon(config_path, bar_name +":indicator", format.find("%indicator%") != std::string::npos, ""));
-    bar->set_fill(get_config_icon(config_path, bar_name +":fill", format.find("%fill%") != std::string::npos, ""));
-    bar->set_empty(get_config_icon(config_path, bar_name +":empty", format.find("%empty%") != std::string::npos, ""));
+    bar->set_gradient(config::get<bool>(config_path, bar_name +"-gradient", true));
+    bar->set_colors(config::get_list<std::string>(config_path, bar_name +"-foreground", {}));
+    bar->set_indicator(get_config_icon(config_path, bar_name +"-indicator", format.find("%indicator%") != std::string::npos, ""));
+    bar->set_fill(get_config_icon(config_path, bar_name +"-fill", format.find("%fill%") != std::string::npos, ""));
+    bar->set_empty(get_config_icon(config_path, bar_name +"-empty", format.find("%empty%") != std::string::npos, ""));
 
     return bar;
   }

--- a/src/drawtypes/label.cpp
+++ b/src/drawtypes/label.cpp
@@ -31,13 +31,13 @@ namespace drawtypes
       label = config::get<std::string>(config_path, label_name, def);
 
     return std::unique_ptr<Label> { new Label(label,
-      config::get<std::string>(config_path, label_name +":foreground", ""),
-      config::get<std::string>(config_path, label_name +":background", ""),
-      config::get<std::string>(config_path, label_name +":underline", ""),
-      config::get<std::string>(config_path, label_name +":overline", ""),
-      config::get<int>(config_path, label_name +":font", 0),
-      config::get<int>(config_path, label_name +":padding", 0),
-      config::get<int>(config_path, label_name +":margin", 0)) };
+      config::get<std::string>(config_path, label_name +"-foreground", ""),
+      config::get<std::string>(config_path, label_name +"-background", ""),
+      config::get<std::string>(config_path, label_name +"-underline", ""),
+      config::get<std::string>(config_path, label_name +"-overline", ""),
+      config::get<int>(config_path, label_name +"-font", 0),
+      config::get<int>(config_path, label_name +"-padding", 0),
+      config::get<int>(config_path, label_name +"-margin", 0)) };
   }
 
   std::unique_ptr<Label> get_optional_config_label(const std::string& config_path, const std::string& label_name, const std::string& def) {

--- a/src/drawtypes/ramp.cpp
+++ b/src/drawtypes/ramp.cpp
@@ -17,7 +17,7 @@ namespace drawtypes
     auto n_icons = icons.size();
     repeat(n_icons)
     {
-      auto ramp = ramp_name +":"+ std::to_string(repeat_i_rev(n_icons));
+      auto ramp = ramp_name +"-"+ std::to_string(repeat_i_rev(n_icons));
       vec.emplace_back(std::unique_ptr<Icon> { get_optional_config_icon(config_path, ramp, icons[repeat_i_rev(n_icons)]) });
     }
 

--- a/src/modules/bspwm.cpp
+++ b/src/modules/bspwm.cpp
@@ -14,7 +14,7 @@
 using namespace modules;
 using namespace Bspwm;
 
-#define DEFAULT_WS_ICON "workspace_icon:default"
+#define DEFAULT_WS_ICON "workspace_icon-default"
 #define DEFAULT_WS_LABEL "%icon%  %name%"
 
 BspwmModule::BspwmModule(const std::string& name_, const std::string& monitor)
@@ -23,21 +23,21 @@ BspwmModule::BspwmModule(const std::string& name_, const std::string& monitor)
   this->formatter->add(DEFAULT_FORMAT, TAG_LABEL_STATE, { TAG_LABEL_STATE }, { TAG_LABEL_MODE });
 
   if (this->formatter->has(TAG_LABEL_STATE)) {
-    this->state_labels.insert(std::make_pair(WORKSPACE_ACTIVE, drawtypes::get_optional_config_label(name(), "label:active", DEFAULT_WS_LABEL)));
-    this->state_labels.insert(std::make_pair(WORKSPACE_OCCUPIED, drawtypes::get_optional_config_label(name(), "label:occupied", DEFAULT_WS_LABEL)));
-    this->state_labels.insert(std::make_pair(WORKSPACE_URGENT, drawtypes::get_optional_config_label(name(), "label:urgent", DEFAULT_WS_LABEL)));
-    this->state_labels.insert(std::make_pair(WORKSPACE_EMPTY, drawtypes::get_optional_config_label(name(), "label:empty", DEFAULT_WS_LABEL)));
-    this->state_labels.insert(std::make_pair(WORKSPACE_DIMMED, drawtypes::get_optional_config_label(name(), "label:dimmed")));
+    this->state_labels.insert(std::make_pair(WORKSPACE_ACTIVE, drawtypes::get_optional_config_label(name(), "label-active", DEFAULT_WS_LABEL)));
+    this->state_labels.insert(std::make_pair(WORKSPACE_OCCUPIED, drawtypes::get_optional_config_label(name(), "label-occupied", DEFAULT_WS_LABEL)));
+    this->state_labels.insert(std::make_pair(WORKSPACE_URGENT, drawtypes::get_optional_config_label(name(), "label-urgent", DEFAULT_WS_LABEL)));
+    this->state_labels.insert(std::make_pair(WORKSPACE_EMPTY, drawtypes::get_optional_config_label(name(), "label-empty", DEFAULT_WS_LABEL)));
+    this->state_labels.insert(std::make_pair(WORKSPACE_DIMMED, drawtypes::get_optional_config_label(name(), "label-dimmed")));
   }
 
   if (this->formatter->has(TAG_LABEL_MODE)) {
-    this->mode_labels.insert(std::make_pair(MODE_LAYOUT_MONOCLE, drawtypes::get_optional_config_label(name(), "label:monocle")));
-    this->mode_labels.insert(std::make_pair(MODE_LAYOUT_TILED, drawtypes::get_optional_config_label(name(), "label:tiled")));
-    this->mode_labels.insert(std::make_pair(MODE_STATE_FULLSCREEN, drawtypes::get_optional_config_label(name(), "label:fullscreen")));
-    this->mode_labels.insert(std::make_pair(MODE_STATE_FLOATING, drawtypes::get_optional_config_label(name(), "label:floating")));
-    this->mode_labels.insert(std::make_pair(MODE_NODE_LOCKED, drawtypes::get_optional_config_label(name(), "label:locked")));
-    this->mode_labels.insert(std::make_pair(MODE_NODE_STICKY, drawtypes::get_optional_config_label(name(), "label:sticky")));
-    this->mode_labels.insert(std::make_pair(MODE_NODE_PRIVATE, drawtypes::get_optional_config_label(name(), "label:private")));
+    this->mode_labels.insert(std::make_pair(MODE_LAYOUT_MONOCLE, drawtypes::get_optional_config_label(name(), "label-monocle")));
+    this->mode_labels.insert(std::make_pair(MODE_LAYOUT_TILED, drawtypes::get_optional_config_label(name(), "label-tiled")));
+    this->mode_labels.insert(std::make_pair(MODE_STATE_FULLSCREEN, drawtypes::get_optional_config_label(name(), "label-fullscreen")));
+    this->mode_labels.insert(std::make_pair(MODE_STATE_FLOATING, drawtypes::get_optional_config_label(name(), "label-floating")));
+    this->mode_labels.insert(std::make_pair(MODE_NODE_LOCKED, drawtypes::get_optional_config_label(name(), "label-locked")));
+    this->mode_labels.insert(std::make_pair(MODE_NODE_STICKY, drawtypes::get_optional_config_label(name(), "label-sticky")));
+    this->mode_labels.insert(std::make_pair(MODE_NODE_PRIVATE, drawtypes::get_optional_config_label(name(), "label-private")));
   }
 
   this->icons = std::make_unique<drawtypes::IconMap>();

--- a/src/modules/i3.cpp
+++ b/src/modules/i3.cpp
@@ -16,7 +16,7 @@
 
 using namespace modules;
 
-#define DEFAULT_WS_ICON "workspace_icon:default"
+#define DEFAULT_WS_ICON "workspace_icon-default"
 #define DEFAULT_WS_LABEL "%icon% %name%"
 
 // TODO: Needs more testing
@@ -40,11 +40,11 @@ i3Module::i3Module(const std::string& name_, const std::string& monitor) : Event
   this->formatter->add(DEFAULT_FORMAT, TAG_LABEL_STATE, { TAG_LABEL_STATE });
 
   if (this->formatter->has(TAG_LABEL_STATE)) {
-    this->state_labels.insert(std::make_pair(i3::WORKSPACE_FOCUSED, drawtypes::get_optional_config_label(name(), "label:focused", DEFAULT_WS_LABEL)));
-    this->state_labels.insert(std::make_pair(i3::WORKSPACE_UNFOCUSED, drawtypes::get_optional_config_label(name(), "label:unfocused", DEFAULT_WS_LABEL)));
-    this->state_labels.insert(std::make_pair(i3::WORKSPACE_VISIBLE, drawtypes::get_optional_config_label(name(), "label:visible", DEFAULT_WS_LABEL)));
-    this->state_labels.insert(std::make_pair(i3::WORKSPACE_URGENT, drawtypes::get_optional_config_label(name(), "label:urgent", DEFAULT_WS_LABEL)));
-    this->state_labels.insert(std::make_pair(i3::WORKSPACE_DIMMED, drawtypes::get_optional_config_label(name(), "label:dimmed")));
+    this->state_labels.insert(std::make_pair(i3::WORKSPACE_FOCUSED, drawtypes::get_optional_config_label(name(), "label-focused", DEFAULT_WS_LABEL)));
+    this->state_labels.insert(std::make_pair(i3::WORKSPACE_UNFOCUSED, drawtypes::get_optional_config_label(name(), "label-unfocused", DEFAULT_WS_LABEL)));
+    this->state_labels.insert(std::make_pair(i3::WORKSPACE_VISIBLE, drawtypes::get_optional_config_label(name(), "label-visible", DEFAULT_WS_LABEL)));
+    this->state_labels.insert(std::make_pair(i3::WORKSPACE_URGENT, drawtypes::get_optional_config_label(name(), "label-urgent", DEFAULT_WS_LABEL)));
+    this->state_labels.insert(std::make_pair(i3::WORKSPACE_DIMMED, drawtypes::get_optional_config_label(name(), "label-dimmed")));
   }
 
   this->icons = std::make_unique<drawtypes::IconMap>();

--- a/src/modules/menu.cpp
+++ b/src/modules/menu.cpp
@@ -12,17 +12,17 @@ MenuModule::MenuModule(const std::string& name_) : StaticModule(name_)
   this->formatter->add(DEFAULT_FORMAT, default_format_string, { TAG_LABEL_TOGGLE, TAG_MENU });
 
   if (this->formatter->has(TAG_LABEL_TOGGLE)) {
-    this->label_open = drawtypes::get_config_label(name(), "label:open");
-    this->label_close = drawtypes::get_optional_config_label(name(), "label:close", "x");
+    this->label_open = drawtypes::get_config_label(name(), "label-open");
+    this->label_close = drawtypes::get_optional_config_label(name(), "label-close", "x");
   }
 
   if (this->formatter->has(TAG_MENU)) {
     int level_n = 0;
 
     while (true) {
-      auto level_path = "menu:"+ std::to_string(level_n);
+      auto level_path = "menu-"+ std::to_string(level_n);
 
-      if (config::get<std::string>(name(), level_path +":0", "") == "")
+      if (config::get<std::string>(name(), level_path +"-0", "") == "")
         break;
 
       this->levels.emplace_back(std::make_unique<MenuTree>());
@@ -30,7 +30,7 @@ MenuModule::MenuModule(const std::string& name_) : StaticModule(name_)
       int item_n = 0;
 
       while (true) {
-        auto item_path = level_path +":"+ std::to_string(item_n);
+        auto item_path = level_path +"-"+ std::to_string(item_n);
 
         if (config::get<std::string>(name(), item_path, "") == "")
           break;
@@ -38,7 +38,7 @@ MenuModule::MenuModule(const std::string& name_) : StaticModule(name_)
         auto item = std::make_unique<MenuTreeItem>();
 
         item->label = drawtypes::get_config_label(name(), item_path);
-        item->exec = config::get<std::string>(name(), item_path +":exec", EVENT_MENU_CLOSE);
+        item->exec = config::get<std::string>(name(), item_path +"-exec", EVENT_MENU_CLOSE);
 
         this->levels.back()->items.emplace_back(std::move(item));
 

--- a/src/modules/mpd.cpp
+++ b/src/modules/mpd.cpp
@@ -45,8 +45,8 @@ MpdModule::MpdModule(const std::string& name_)
     this->label_time_tokenized = this->label_time->clone();
   }
   if (this->formatter->has(TAG_ICON_RANDOM) || this->formatter->has(TAG_ICON_REPEAT) || this->formatter->has(TAG_ICON_REPEAT_ONE)) {
-    this->toggle_on_color = config::get<std::string>(name(), "toggle_on:foreground", "");
-    this->toggle_off_color = config::get<std::string>(name(), "toggle_off:foreground", "");
+    this->toggle_on_color = config::get<std::string>(name(), "toggle_on-foreground", "");
+    this->toggle_off_color = config::get<std::string>(name(), "toggle_off-foreground", "");
   }
   if (this->formatter->has(TAG_LABEL_OFFLINE, FORMAT_OFFLINE))
     this->label_offline = drawtypes::get_config_label(name(), get_tag_name(TAG_LABEL_OFFLINE));


### PR DESCRIPTION
Colons break ini syntax highlighters and linters and there isn't really a good reason for using them. Just an unfortunate choice that would be good to fix early on.

How to deal with backward compatibility?