### PR TITLE
Revert "fix(xpp): Submodule ref"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 [submodule "lib/xpp"]
 	path = lib/xpp
 	url = https://github.com/jaagr/xpp
-	branch = 1.2.0
+	branch = 1.0.0


### PR DESCRIPTION
The new xpp version caused the aur pkgbuilds to break (see #58)
This reverts commit 208fd2afa555f2e0f8ea3a341f22647c0b07ec7b.
Fixes https://github.com/jaagr/lemonbuddy/issues/58