### PR TITLE
Remove python executable replacment in PKGBUILD

### DIFF
--- a/contrib/lemonbuddy-git.aur/.SRCINFO
+++ b/contrib/lemonbuddy-git.aur/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = lemonbuddy-git
 	pkgdesc = A fast and easy-to-use tool for Lemonbar
 	pkgver = 1.4.4
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/jaagr/lemonbuddy
 	arch = i686
 	arch = x86_64

--- a/contrib/lemonbuddy-git.aur/PKGBUILD
+++ b/contrib/lemonbuddy-git.aur/PKGBUILD
@@ -3,7 +3,7 @@
 _pkgname=lemonbuddy
 pkgname="${_pkgname}-git"
 pkgver=1.4.4
-pkgrel=1
+pkgrel=2
 pkgdesc="A fast and easy-to-use tool for Lemonbar"
 arch=("i686" "x86_64")
 url="https://github.com/jaagr/lemonbuddy"
@@ -30,7 +30,6 @@ prepare() {
   cd "$_pkgname" || exit
   git submodule update --init --recursive
   mkdir build
-  sed 's/python2.7/python3.5/g' -i lib/xpp/CMakeLists.txt
 }
 
 build() {


### PR DESCRIPTION
Only for the '-git' package since the other one would also require a
version bump