### PR TITLE
feat(i3): Scrollable workspaces and strip-wsnumber option

### DIFF
--- a/include/modules/i3.hpp
+++ b/include/modules/i3.hpp
@@ -226,10 +226,10 @@ namespace modules {
           ipc.send_command("workspace number " + cmd.substr(strlen(EVENT_CLICK)));
         } else if (cmd.compare(0, strlen(EVENT_SCROLL_DOWN), EVENT_SCROLL_DOWN) == 0) {
           m_log.info("%s: Sending workspace prev command to ipc handler", name());
-          ipc.send_command("workspace next");
+          ipc.send_command("workspace next_on_output");
         } else if (cmd.compare(0, strlen(EVENT_SCROLL_UP), EVENT_SCROLL_UP) == 0) {
           m_log.info("%s: Sending workspace next command to ipc handler", name());
-          ipc.send_command("workspace prev");
+          ipc.send_command("workspace prev_on_output");
         }
       } catch (const std::exception& err) {
         m_log.err("%s: %s", name(), err.what());


### PR DESCRIPTION
Hello,

I like to be able to scroll through my workspaces, so I added scroll up and down events which send the command `workspace next` or `workspace prev`.

I also added the option `strip-wsnumbers` which is a feature of i3bar. If set to true the workspace label is split by `:` and only the second part is shown. This makes it possible to use numbered workspaces but only show the name.

