### PR TITLE
feat(volume): Added volume mapping

### DIFF
--- a/include/adapters/alsa.hpp
+++ b/include/adapters/alsa.hpp
@@ -3,12 +3,15 @@
 #include <stdio.h>
 #include <functional>
 #include <string>
+#include <cmath>
 
 #include <alsa/asoundlib.h>
 
 #include "common.hpp"
 #include "config.hpp"
 #include "utils/threading.hpp"
+
+#define MAX_LINEAR_DB_SCALE 24
 
 LEMONBUDDY_NS
 
@@ -64,7 +67,9 @@ class alsa_mixer {
   int process_events();
 
   int get_volume();
+  int get_normalized_volume();
   void set_volume(float percentage);
+  void set_normalized_volume(float percentage);
   void set_mute(bool mode);
   void toggle_mute();
   bool is_muted();

--- a/include/modules/volume.hpp
+++ b/include/modules/volume.hpp
@@ -57,6 +57,8 @@ namespace modules {
 
     int m_headphoneid = 0;
 
+    bool m_mapped;
+
     stateflag m_muted{false};
     stateflag m_headphones{false};
 

--- a/src/modules/volume.cpp
+++ b/src/modules/volume.cpp
@@ -14,6 +14,7 @@ namespace modules {
     GET_CONFIG_VALUE(name(), master_mixer_name, "master-mixer");
     GET_CONFIG_VALUE(name(), speaker_mixer_name, "speaker-mixer");
     GET_CONFIG_VALUE(name(), headphone_mixer_name, "headphone-mixer");
+    m_mapped = m_conf.get<bool>(name(), "mapped", false);
 
     if (!headphone_mixer_name.empty())
       REQ_CONFIG_VALUE(name(), m_headphoneid, "headphone-id");
@@ -110,16 +111,19 @@ namespace modules {
     m_headphones = false;
 
     if (m_mixers[mixer::MASTER]) {
-      m_volume = m_volume * m_mixers[mixer::MASTER]->get_volume() / 100.0f;
+      m_volume = m_volume * (m_mapped ? m_mixers[mixer::MASTER]->get_normalized_volume() / 100.0f :
+        m_mixers[mixer::MASTER]->get_volume() / 100.0f);
       m_muted = m_muted || m_mixers[mixer::MASTER]->is_muted();
     }
 
     if (m_controls[control::HEADPHONE] && m_controls[control::HEADPHONE]->test_device_plugged()) {
       m_headphones = true;
-      m_volume = m_volume * m_mixers[mixer::HEADPHONE]->get_volume() / 100.0f;
+      m_volume = m_volume * (m_mapped ? m_mixers[mixer::HEADPHONE]->get_normalized_volume() / 100.0f :
+        m_mixers[mixer::HEADPHONE]->get_volume() / 100.0f);
       m_muted = m_muted || m_mixers[mixer::HEADPHONE]->is_muted();
     } else if (m_mixers[mixer::SPEAKER]) {
-      m_volume = m_volume * m_mixers[mixer::SPEAKER]->get_volume() / 100.0f;
+      m_volume = m_volume * (m_mapped ? m_mixers[mixer::SPEAKER]->get_normalized_volume() / 100.0f :
+        m_mixers[mixer::SPEAKER]->get_volume() / 100.0f);
       m_muted = m_muted || m_mixers[mixer::SPEAKER]->is_muted();
     }
 
@@ -196,11 +200,15 @@ namespace modules {
         }
       } else if (cmd.compare(0, strlen(EVENT_VOLUME_UP), EVENT_VOLUME_UP) == 0) {
         for (auto&& mixer : mixers) {
-          mixer->set_volume(math_util::cap<float>(mixer->get_volume() + 5, 0, 100));
+          m_mapped ?
+            mixer->set_normalized_volume(math_util::cap<float>(mixer->get_normalized_volume() + 5, 0, 100)) :
+            mixer->set_volume(math_util::cap<float>(mixer->get_volume() + 5, 0, 100));
         }
       } else if (cmd.compare(0, strlen(EVENT_VOLUME_DOWN), EVENT_VOLUME_DOWN) == 0) {
         for (auto&& mixer : mixers) {
-          mixer->set_volume(math_util::cap<float>(mixer->get_volume() - 5, 0, 100));
+          m_mapped ?
+            mixer->set_normalized_volume(math_util::cap<float>(mixer->get_normalized_volume() - 5, 0, 100)) :
+            mixer->set_volume(math_util::cap<float>(mixer->get_volume() - 5, 0, 100));
         }
       } else {
         return false;


### PR DESCRIPTION
I'm used to the volume mapping used by `amixer -M` and `alsamixer`, so I thought it would be useful to have an option which displays the volume this way instead of the raw percentage.